### PR TITLE
Phase A: test harness, drift checks, and a platform-neutral core

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ set(CORE_SOURCES
     src/core/input/keyboard.cpp
     src/core/disassembler/disassembler.cpp
     src/core/cards/mockingboard/ay8910.cpp
+    src/core/debug/debug_log.cpp
     src/core/cards/mockingboard/via6522.cpp
     src/core/cards/mockingboard/mockingboard_card.cpp
     src/core/cards/disk2/disk2_card.cpp
@@ -434,6 +435,7 @@ else()
         src/core/input/keyboard.cpp
         src/core/disassembler/disassembler.cpp
         src/core/cards/mockingboard/ay8910.cpp
+        src/core/debug/debug_log.cpp
         src/core/cards/mockingboard/via6522.cpp
         src/core/cards/mockingboard/mockingboard_card.cpp
         src/core/cards/disk2/disk2_card.cpp
@@ -549,6 +551,7 @@ else()
         src/core/cards/mockingboard/mockingboard_card.cpp
         src/core/cards/mockingboard/via6522.cpp
         src/core/cards/mockingboard/ay8910.cpp
+        src/core/debug/debug_log.cpp
     )
 
     # Keyboard (only keyboard.cpp)
@@ -561,6 +564,7 @@ else()
     add_catch2_test(test_ay8910
         tests/unit/test_ay8910.cpp
         src/core/cards/mockingboard/ay8910.cpp
+        src/core/debug/debug_log.cpp
     )
 
     # VIA 6522 (via6522.cpp + ay8910.cpp since VIA connects to PSG)
@@ -568,6 +572,7 @@ else()
         tests/unit/test_via6522.cpp
         src/core/cards/mockingboard/via6522.cpp
         src/core/cards/mockingboard/ay8910.cpp
+        src/core/debug/debug_log.cpp
     )
 
     # Block device (only block_device.cpp)
@@ -647,6 +652,7 @@ else()
         src/core/cards/mockingboard/mockingboard_card.cpp
         src/core/cards/mockingboard/via6522.cpp
         src/core/cards/mockingboard/ay8910.cpp
+        src/core/debug/debug_log.cpp
     )
 
     # Thunderclock (Catch2 version)
@@ -707,6 +713,7 @@ else()
         src/core/cards/smartport/block_device.cpp
         src/core/cards/mockingboard/via6522.cpp
         src/core/cards/mockingboard/ay8910.cpp
+        src/core/debug/debug_log.cpp
         src/core/disk-image/dsk_disk_image.cpp
         src/core/disk-image/woz_disk_image.cpp
         src/core/disk-image/gcr_encoding.cpp
@@ -770,6 +777,12 @@ else()
     add_catch2_test(test_condition_evaluator
         tests/unit/test_condition_evaluator.cpp
         ${CORE_TEST_SOURCES}
+    )
+
+    # Debug log sink (only debug_log.cpp)
+    add_catch2_test(test_debug_log
+        tests/unit/test_debug_log.cpp
+        src/core/debug/debug_log.cpp
     )
 
 endif()

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "devDependencies": {
         "vite": "^7.3.1",
+        "vitest": "^4.1.10",
         "ws": "^8.19.0"
       }
     },
@@ -454,6 +455,13 @@
         "node": ">=18"
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.54.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.54.0.tgz",
@@ -762,10 +770,182 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
       "dev": true,
       "license": "MIT"
     },
@@ -811,6 +991,26 @@
         "@esbuild/win32-x64": "0.27.3"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -844,6 +1044,16 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -862,6 +1072,27 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -954,6 +1185,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -962,6 +1200,37 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
@@ -979,6 +1248,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/vite": {
@@ -1054,6 +1333,113 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ws": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,11 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "check:exports": "scripts/check-exports.sh",
+    "check:core-purity": "scripts/check-core-purity.sh",
+    "check": "npm run check:exports && npm run check:core-purity && npm test",
     "build": "npm run build:wasm && vite build",
     "build:wasm": "mkdir -p build && cd build && emcmake cmake .. && emmake make -j$(nproc 2>/dev/null || sysctl -n hw.ncpu)",
     "preview": "vite preview",
@@ -14,6 +19,7 @@
   },
   "devDependencies": {
     "vite": "^7.3.1",
+    "vitest": "^4.1.10",
     "ws": "^8.19.0"
   }
 }

--- a/scripts/check-core-purity.sh
+++ b/scripts/check-core-purity.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# check-core-purity.sh - Assert src/core/ has no host-platform dependencies
+#
+# src/core/ is the shared emulation core: pure C++ that knows nothing about the
+# program hosting it. Platform glue belongs in src/bindings/. When that rule
+# erodes, the core stops being portable and stops being testable outside a
+# browser — the Mockingboard's EM_ASM console tracing was exactly that, and it
+# meant the native test binaries silently lost the logging.
+#
+# Debug output now goes through a2e::debugLog(), which the host wires to
+# wherever it wants (see src/core/debug/debug_log.hpp).
+#
+# Patterns match code, not prose, so documentation may still name the thing it
+# is warning about.
+#
+# Written by
+#  Mike Daley <michael_daley@icloud.com>
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CORE="$ROOT/src/core"
+
+[ -d "$CORE" ] || { echo "check-core-purity: missing $CORE" >&2; exit 2; }
+
+# name : extended-regex : explanation
+CHECKS=(
+  "Emscripten macro|__EMSCRIPTEN__|conditional compilation on the browser host"
+  "Inline JavaScript|EM_ASM[[:space:]]*\(|inline JS; use a2e::debugLog() or a host callback"
+  "Emscripten header|#[[:space:]]*include[[:space:]]*<emscripten|Emscripten SDK header"
+  "Emscripten bind|emscripten::|Embind types leak the host into the core"
+)
+
+status=0
+
+for check in "${CHECKS[@]}"; do
+  IFS='|' read -r name pattern explanation <<< "$check"
+
+  # --include limits the sweep to sources; -E for extended regex.
+  if hits="$(grep -rnE --include='*.cpp' --include='*.hpp' --include='*.h' \
+              -- "$pattern" "$CORE" 2>/dev/null)"; then
+    echo "check-core-purity: $name found in src/core/ — $explanation" >&2
+    echo "$hits" | sed "s|^$ROOT/|  |" >&2
+    status=1
+  fi
+done
+
+if [ "$status" -eq 0 ]; then
+  files=$(find "$CORE" \( -name '*.cpp' -o -name '*.hpp' -o -name '*.h' \) | wc -l | tr -d ' ')
+  echo "check-core-purity: OK ($files core files, no host dependencies)"
+fi
+
+exit "$status"

--- a/scripts/check-exports.sh
+++ b/scripts/check-exports.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# check-exports.sh - Verify the WASM export list matches the bindings
+#
+# EXPORTED_FUNCTIONS in CMakeLists.txt is hand-maintained. Nothing has ever
+# checked it against the functions actually defined in src/bindings, so the two
+# can drift silently in both directions:
+#
+#   - a function defined with EMSCRIPTEN_KEEPALIVE but missing from the list is
+#     dead-stripped by the linker, and the JS call fails at runtime;
+#   - a name in the list with no matching definition is a stale entry that
+#     survives long after the function it referred to was renamed or removed.
+#
+# Both are caught here. Exits non-zero on any mismatch.
+#
+# Written by
+#  Mike Daley <michael_daley@icloud.com>
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BINDINGS="$ROOT/src/bindings/wasm_interface.cpp"
+CMAKE="$ROOT/CMakeLists.txt"
+
+[ -f "$BINDINGS" ] || { echo "check-exports: missing $BINDINGS" >&2; exit 2; }
+[ -f "$CMAKE" ]    || { echo "check-exports: missing $CMAKE" >&2; exit 2; }
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+# Defined: the line after each EMSCRIPTEN_KEEPALIVE is the function signature.
+# Take the identifier immediately before the opening parenthesis.
+grep -A1 '^EMSCRIPTEN_KEEPALIVE$' "$BINDINGS" \
+  | grep -v '^EMSCRIPTEN_KEEPALIVE$' \
+  | grep -v '^--$' \
+  | sed -n 's/.*[^A-Za-z0-9_]\([A-Za-z_][A-Za-z0-9_]*\)[[:space:]]*(.*/\1/p' \
+  | sort -u > "$tmp/defined"
+
+# Exported: quoted "_name" entries inside the EXPORTED_FUNCTIONS block. The
+# leading underscore is Emscripten's C symbol prefix, not part of the name.
+sed -n '/EXPORTED_FUNCTIONS/,/EXPORTED_RUNTIME_METHODS\|^[[:space:]]*-s /p' "$CMAKE" \
+  | grep -o '\\"_[A-Za-z0-9_]*\\"' \
+  | tr -d '\\"' \
+  | sed 's/^_//' \
+  | sort -u > "$tmp/exported"
+
+# Emscripten provides these itself; they are legitimately in the list without a
+# definition in our bindings.
+cat > "$tmp/builtin" <<'EOF'
+free
+malloc
+EOF
+
+comm -23 "$tmp/defined" "$tmp/exported" > "$tmp/missing"
+comm -13 "$tmp/defined" "$(sort -u "$tmp/builtin" > "$tmp/builtin.s"; echo "$tmp/exported")" \
+  | comm -23 - "$tmp/builtin.s" > "$tmp/stale"
+
+status=0
+
+if [ -s "$tmp/missing" ]; then
+  echo "check-exports: defined with EMSCRIPTEN_KEEPALIVE but NOT in EXPORTED_FUNCTIONS:" >&2
+  sed 's/^/  - /' "$tmp/missing" >&2
+  echo "  → these will be dead-stripped by the linker and fail at runtime." >&2
+  status=1
+fi
+
+if [ -s "$tmp/stale" ]; then
+  echo "check-exports: listed in EXPORTED_FUNCTIONS but NOT defined in bindings:" >&2
+  sed 's/^/  - /' "$tmp/stale" >&2
+  echo "  → stale entries; remove them from CMakeLists.txt." >&2
+  status=1
+fi
+
+if [ "$status" -eq 0 ]; then
+  echo "check-exports: OK ($(wc -l < "$tmp/defined" | tr -d ' ') functions in sync)"
+fi
+
+exit "$status"

--- a/src/bindings/wasm_interface.cpp
+++ b/src/bindings/wasm_interface.cpp
@@ -14,6 +14,7 @@
 #include "../core/filesystem/pascal.hpp"
 #include "../core/basic/basic_detokenizer.hpp"
 #include "../core/basic/basic_tokenizer.hpp"
+#include "../core/debug/debug_log.hpp"
 #include "../core/input/keyboard.hpp"
 #include <cstdlib>
 #include <cstring>
@@ -35,6 +36,13 @@ extern "C" {
 EMSCRIPTEN_KEEPALIVE
 void init() {
   if (!g_emulator) {
+    // Route core debug tracing to the browser console. The core itself has no
+    // idea a console exists — it formats into a2e::debugLog() and this binding,
+    // as the platform layer, decides where the text goes.
+    a2e::setDebugLogSink([](const char *message) {
+      EM_ASM({ console.log(UTF8ToString($0)); }, message);
+    });
+
     g_emulator = new a2e::Emulator();
     g_emulator->init();
     // Install the parallel (Centronics) printer tx callback at construction so

--- a/src/core/cards/mockingboard/ay8910.cpp
+++ b/src/core/cards/mockingboard/ay8910.cpp
@@ -7,9 +7,7 @@
 
 #include "ay8910.hpp"
 #include <cmath>
-#ifdef __EMSCRIPTEN__
-#include <emscripten.h>
-#endif
+#include "../../debug/debug_log.hpp"
 
 namespace a2e {
 
@@ -90,18 +88,10 @@ void AY8910::writeRegister(uint8_t value) {
     // Apply register write immediately
     applyRegisterWrite(currentRegister_, value);
 
-#ifdef __EMSCRIPTEN__
     if (debugLogging_) {
-        const char* regName = getRegisterName(currentRegister_);
-        EM_ASM({
-            const reg = $0;
-            const val = $1;
-            const regName = UTF8ToString($2);
-            const psgId = $3;
-            console.log(`PSG${psgId}: R${reg} (${regName}) = $${val.toString(16).toUpperCase().padStart(2,'0')} (${val})`);
-        }, currentRegister_, value, regName, psgId_);
+        debugLog("PSG%d: R%d (%s) = $%02X (%d)", psgId_, currentRegister_,
+                 getRegisterName(currentRegister_), value, value);
     }
-#endif
 }
 
 void AY8910::applyRegisterWrite(uint8_t reg, uint8_t value) {

--- a/src/core/cards/mockingboard/via6522.cpp
+++ b/src/core/cards/mockingboard/via6522.cpp
@@ -7,9 +7,7 @@
 
 #include "via6522.hpp"
 #include "ay8910.hpp"
-#ifdef __EMSCRIPTEN__
-#include <emscripten.h>
-#endif
+#include "../../debug/debug_log.hpp"
 
 namespace a2e {
 
@@ -323,13 +321,9 @@ void VIA6522::updatePSG() {
     if (resetActive && !wasResetActive) {
         // Reset just became active - reset the PSG
         psg_->reset();
-#ifdef __EMSCRIPTEN__
         if (viaDebugLogging_) {
-            EM_ASM({
-                console.log("VIA" + $0 + ": PSG RESET asserted");
-            }, viaId_);
+            debugLog("VIA%d: PSG RESET asserted", viaId_);
         }
-#endif
     }
 
     // Only perform PSG operations on state TRANSITIONS
@@ -340,13 +334,10 @@ void VIA6522::updatePSG() {
     uint8_t prevControl = prevPsgControl_;
     prevPsgControl_ = control;
 
-#ifdef __EMSCRIPTEN__
     if (viaDebugLogging_) {
-        EM_ASM({
-            console.log("VIA" + $4 + ": ctrl " + $0 + "->" + $1 + " ORA=0x" + $2.toString(16) + " DDRA=0x" + $3.toString(16));
-        }, prevControl, control, ora_, ddra_, viaId_);
+        debugLog("VIA%d: ctrl %d->%d ORA=0x%X DDRA=0x%X", viaId_, prevControl,
+                 control, ora_, ddra_);
     }
-#endif
 
     // Compute PSG function from control bits: BC1=bit0, BDIR=bit1
     // 0b00=INACTIVE, 0b01=READ, 0b10=WRITE, 0b11=LATCH
@@ -384,13 +375,9 @@ void VIA6522::updatePSG() {
             psgAddressLatched_ = true;
         } else {
             psgAddressLatched_ = false;
-#ifdef __EMSCRIPTEN__
             if (viaDebugLogging_) {
-                EM_ASM({
-                    console.log("VIA: Rejected invalid address 0x" + $0.toString(16).toUpperCase());
-                }, addr);
+                debugLog("VIA: Rejected invalid address 0x%X", addr);
             }
-#endif
         }
         return;
     }
@@ -400,13 +387,10 @@ void VIA6522::updatePSG() {
         if (psgAddressLatched_) {
             psg_->writeRegister(ora_ & ddra_);
         } else {
-#ifdef __EMSCRIPTEN__
             if (viaDebugLogging_) {
-                EM_ASM({
-                    console.log("VIA: Write rejected - no address latched, data=0x" + $0.toString(16).toUpperCase());
-                }, ora_ & ddra_);
+                debugLog("VIA: Write rejected - no address latched, data=0x%X",
+                         ora_ & ddra_);
             }
-#endif
         }
         return;
     }

--- a/src/core/debug/debug_log.cpp
+++ b/src/core/debug/debug_log.cpp
@@ -1,0 +1,39 @@
+/*
+ * debug_log.cpp - Host-installed debug log sink for the emulation core
+ *
+ * Written by
+ *  Mike Daley <michael_daley@icloud.com>
+ */
+
+#include "debug_log.hpp"
+
+#include <cstdarg>
+#include <cstdio>
+
+namespace a2e {
+
+namespace {
+DebugLogFn g_sink = nullptr;
+
+// Debug lines are short register traces. Anything longer is truncated rather
+// than heap-allocated: this can be called from inside the CPU loop.
+constexpr int MAX_LOG_LINE = 512;
+} // namespace
+
+void setDebugLogSink(DebugLogFn sink) { g_sink = sink; }
+
+bool hasDebugLogSink() { return g_sink != nullptr; }
+
+void debugLog(const char *format, ...) {
+  if (!g_sink || !format) return;
+
+  char buffer[MAX_LOG_LINE];
+  va_list args;
+  va_start(args, format);
+  vsnprintf(buffer, sizeof(buffer), format, args);
+  va_end(args);
+
+  g_sink(buffer);
+}
+
+} // namespace a2e

--- a/src/core/debug/debug_log.hpp
+++ b/src/core/debug/debug_log.hpp
@@ -1,0 +1,38 @@
+/*
+ * debug_log.hpp - Host-installed debug log sink for the emulation core
+ *
+ * The core must not know what kind of program is hosting it. Debug tracing
+ * previously reached the browser console through EM_ASM, which welded the
+ * emulation to Emscripten; anything else linking the core got silence, and
+ * src/core/ stopped being platform-neutral.
+ *
+ * Instead the host installs a sink at startup and the core formats messages
+ * into it. With no sink installed — unit tests, or a host that does not want
+ * the output — formatting is skipped entirely, so a disabled log costs one
+ * null check.
+ *
+ * Written by
+ *  Mike Daley <michael_daley@icloud.com>
+ */
+
+#pragma once
+
+namespace a2e {
+
+/** Receives one fully formatted, NUL-terminated log line (no trailing newline). */
+using DebugLogFn = void (*)(const char *message);
+
+/** Install (or clear, with nullptr) the process-wide debug log sink. */
+void setDebugLogSink(DebugLogFn sink);
+
+/** True when a sink is installed; lets callers skip expensive argument prep. */
+bool hasDebugLogSink();
+
+/** Format printf-style and forward to the sink. No-op when none is installed. */
+void debugLog(const char *format, ...)
+#if defined(__GNUC__) || defined(__clang__)
+    __attribute__((format(printf, 1, 2)))
+#endif
+    ;
+
+} // namespace a2e

--- a/tests/js/printer/__snapshots__/citoh.test.js.snap
+++ b/tests/js/printer/__snapshots__/citoh.test.js.snap
@@ -1,0 +1,325 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AppleDMP — shared C.Itoh behaviour > ESC ! turns bold on and ESC " turns it off 1`] = `
+[
+  "text "A"",
+  "text "B"",
+  "newline",
+  "char x=0 w=4 cols=8 [bold]",
+  "char x=48 w=4 cols=8",
+  "feed line dist=48",
+]
+`;
+
+exports[`AppleDMP — shared C.Itoh behaviour > ESC > selects unidirectional printing, which slews the head home 1`] = `
+[
+  "return",
+]
+`;
+
+exports[`AppleDMP — shared C.Itoh behaviour > ESC > selects unidirectional printing, which slews the head home 2`] = `
+[
+  "line",
+]
+`;
+
+exports[`AppleDMP — shared C.Itoh behaviour > ESC A and ESC B select 6 and 8 lines per inch 1`] = `
+[
+  "text "A"",
+  "newline",
+  "char x=0 w=4 cols=8",
+  "feed line dist=0",
+  "text "B"",
+  "newline",
+  "char x=0 w=4 cols=8",
+  "feed line dist=0",
+]
+`;
+
+exports[`AppleDMP — shared C.Itoh behaviour > ESC M selects the NLQ font, changing the cell row count 1`] = `
+[
+  9,
+]
+`;
+
+exports[`AppleDMP — shared C.Itoh behaviour > ESC X starts underline and ESC Y stops it 1`] = `
+[
+  "text "A"",
+  "text "B"",
+  "newline",
+  "char x=0 w=4 cols=8 [underline]",
+  "char x=48 w=4 cols=8",
+  "feed line dist=48",
+]
+`;
+
+exports[`AppleDMP — shared C.Itoh behaviour > ESC x / ESC y / ESC z select superscript, subscript and normal 1`] = `
+[
+  "text "A"",
+  "text "B"",
+  "text "C"",
+  "newline",
+  "char x=0 w=4 cols=8",
+  "char x=48 w=4 cols=8",
+  "char x=96 w=4 cols=8",
+  "feed line dist=96",
+]
+`;
+
+exports[`AppleDMP — shared C.Itoh behaviour > form feed ejects the page 1`] = `
+[
+  "text "A"",
+  "newline",
+  "char x=0 w=4 cols=8",
+  "feed line dist=0",
+  "formfeed",
+  "feed return dist=0",
+]
+`;
+
+exports[`AppleDMP — shared C.Itoh behaviour > prints a plain line terminated by CR LF 1`] = `
+[
+  "text "H"",
+  "text "E"",
+  "text "L"",
+  "text "L"",
+  "text "O"",
+  "newline",
+  "char x=0 w=4 cols=8",
+  "char x=48 w=4 cols=8",
+  "char x=96 w=4 cols=8",
+  "char x=144 w=4 cols=8",
+  "char x=192 w=4 cols=8",
+  "feed line dist=192",
+]
+`;
+
+exports[`ImageWriter II — colour ribbon > ESC K n selects the ribbon colour band when a colour cart is loaded 1`] = `
+[
+  "black",
+  "yellow",
+  "magenta",
+  "cyan",
+  "orange",
+  "green",
+  "purple",
+]
+`;
+
+exports[`ImageWriterI — shared C.Itoh behaviour > ESC ! turns bold on and ESC " turns it off 1`] = `
+[
+  "text "A"",
+  "text "B"",
+  "newline",
+  "char x=0 w=4 cols=8 [bold]",
+  "char x=40 w=4 cols=8",
+  "feed line dist=40",
+]
+`;
+
+exports[`ImageWriterI — shared C.Itoh behaviour > ESC > selects unidirectional printing, which slews the head home 1`] = `
+[
+  "return",
+]
+`;
+
+exports[`ImageWriterI — shared C.Itoh behaviour > ESC > selects unidirectional printing, which slews the head home 2`] = `
+[
+  "line",
+]
+`;
+
+exports[`ImageWriterI — shared C.Itoh behaviour > ESC A and ESC B select 6 and 8 lines per inch 1`] = `
+[
+  "text "A"",
+  "newline",
+  "char x=0 w=4 cols=8",
+  "feed line dist=0",
+  "text "B"",
+  "newline",
+  "char x=0 w=4 cols=8",
+  "feed line dist=0",
+]
+`;
+
+exports[`ImageWriterI — shared C.Itoh behaviour > ESC M selects the NLQ font, changing the cell row count 1`] = `
+[
+  9,
+]
+`;
+
+exports[`ImageWriterI — shared C.Itoh behaviour > ESC X starts underline and ESC Y stops it 1`] = `
+[
+  "text "A"",
+  "text "B"",
+  "newline",
+  "char x=0 w=4 cols=8 [underline]",
+  "char x=40 w=4 cols=8",
+  "feed line dist=40",
+]
+`;
+
+exports[`ImageWriterI — shared C.Itoh behaviour > ESC x / ESC y / ESC z select superscript, subscript and normal 1`] = `
+[
+  "text "A"",
+  "text "B"",
+  "text "C"",
+  "newline",
+  "char x=0 w=4 cols=8",
+  "char x=40 w=4 cols=8",
+  "char x=80 w=4 cols=8",
+  "feed line dist=80",
+]
+`;
+
+exports[`ImageWriterI — shared C.Itoh behaviour > form feed ejects the page 1`] = `
+[
+  "text "A"",
+  "newline",
+  "char x=0 w=4 cols=8",
+  "feed line dist=0",
+  "formfeed",
+  "feed return dist=0",
+]
+`;
+
+exports[`ImageWriterI — shared C.Itoh behaviour > prints a plain line terminated by CR LF 1`] = `
+[
+  "text "H"",
+  "text "E"",
+  "text "L"",
+  "text "L"",
+  "text "O"",
+  "newline",
+  "char x=0 w=4 cols=8",
+  "char x=40 w=4 cols=8",
+  "char x=80 w=4 cols=8",
+  "char x=120 w=4 cols=8",
+  "char x=160 w=4 cols=8",
+  "feed line dist=160",
+]
+`;
+
+exports[`ImageWriterII — shared C.Itoh behaviour > ESC ! turns bold on and ESC " turns it off 1`] = `
+[
+  "text "A"",
+  "text "B"",
+  "newline",
+  "char x=0 w=4 cols=8 [bold]",
+  "char x=48 w=4 cols=12",
+  "feed line dist=48",
+]
+`;
+
+exports[`ImageWriterII — shared C.Itoh behaviour > ESC > selects unidirectional printing, which slews the head home 1`] = `
+[
+  "return",
+]
+`;
+
+exports[`ImageWriterII — shared C.Itoh behaviour > ESC > selects unidirectional printing, which slews the head home 2`] = `
+[
+  "line",
+]
+`;
+
+exports[`ImageWriterII — shared C.Itoh behaviour > ESC A and ESC B select 6 and 8 lines per inch 1`] = `
+[
+  "text "A"",
+  "newline",
+  "char x=0 w=4 cols=12",
+  "feed line dist=0",
+  "text "B"",
+  "newline",
+  "char x=0 w=4 cols=12",
+  "feed line dist=0",
+]
+`;
+
+exports[`ImageWriterII — shared C.Itoh behaviour > ESC M selects the NLQ font, changing the cell row count 1`] = `
+[
+  18,
+]
+`;
+
+exports[`ImageWriterII — shared C.Itoh behaviour > ESC X starts underline and ESC Y stops it 1`] = `
+[
+  "text "A"",
+  "text "B"",
+  "newline",
+  "char x=0 w=4 cols=12 [underline]",
+  "char x=48 w=4 cols=12",
+  "feed line dist=48",
+]
+`;
+
+exports[`ImageWriterII — shared C.Itoh behaviour > ESC x / ESC y / ESC z select superscript, subscript and normal 1`] = `
+[
+  "text "A"",
+  "text "B"",
+  "text "C"",
+  "newline",
+  "char x=0 w=4 cols=8 [super]",
+  "char x=48 w=4 cols=8 [sub]",
+  "char x=96 w=4 cols=12",
+  "feed line dist=96",
+]
+`;
+
+exports[`ImageWriterII — shared C.Itoh behaviour > form feed ejects the page 1`] = `
+[
+  "text "A"",
+  "newline",
+  "char x=0 w=4 cols=12",
+  "feed line dist=0",
+  "formfeed",
+  "feed return dist=0",
+]
+`;
+
+exports[`ImageWriterII — shared C.Itoh behaviour > prints a plain line terminated by CR LF 1`] = `
+[
+  "text "H"",
+  "text "E"",
+  "text "L"",
+  "text "L"",
+  "text "O"",
+  "newline",
+  "char x=0 w=4 cols=12",
+  "char x=48 w=4 cols=12",
+  "char x=96 w=4 cols=12",
+  "char x=144 w=4 cols=12",
+  "char x=192 w=4 cols=12",
+  "feed line dist=192",
+]
+`;
+
+exports[`model identity and metrics > AppleDMP reports stable name, id and dpi 1`] = `
+{
+  "colorRibbon": false,
+  "cps": 120,
+  "dpi": 480,
+  "id": "apple-dmp",
+  "name": "Apple DMP",
+}
+`;
+
+exports[`model identity and metrics > ImageWriterI reports stable name, id and dpi 1`] = `
+{
+  "colorRibbon": false,
+  "cps": 120,
+  "dpi": 480,
+  "id": "imagewriter-i",
+  "name": "ImageWriter I",
+}
+`;
+
+exports[`model identity and metrics > ImageWriterII reports stable name, id and dpi 1`] = `
+{
+  "colorRibbon": true,
+  "cps": 250,
+  "dpi": 480,
+  "id": "imagewriter-ii",
+  "name": "ImageWriter II",
+}
+`;

--- a/tests/js/printer/__snapshots__/epson-fx80.test.js.snap
+++ b/tests/js/printer/__snapshots__/epson-fx80.test.js.snap
@@ -1,0 +1,145 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`EpsonFX80 — bit-image graphics > ESC K emits one dot column per data byte 1`] = `
+[
+  "newline",
+  "dots 0b010000000 x=0 w=8",
+  "dots 0b010000001 x=8 w=8",
+  "dots 0b011111111 x=16 w=8",
+  "dots 0b000000000 x=24 w=8",
+  "feed line dist=24",
+]
+`;
+
+exports[`EpsonFX80 — bit-image graphics > a zero-length graphics run consumes no data bytes 1`] = `
+[
+  "text "A"",
+  "text "B"",
+  "newline",
+  "char x=0 w=4 cols=12",
+  "char x=48 w=4 cols=12",
+  "feed line dist=48",
+]
+`;
+
+exports[`EpsonFX80 — character attributes > ESC - 1 turns on underline, ESC - 0 turns it off 1`] = `
+[
+  "text "A"",
+  "text "B"",
+  "newline",
+  "char x=0 w=4 cols=12 [underline]",
+  "char x=48 w=4 cols=12",
+  "feed line dist=48",
+]
+`;
+
+exports[`EpsonFX80 — character attributes > ESC 4 turns on italic, ESC 5 cancels it 1`] = `
+[
+  "text "A"",
+  "text "B"",
+  "newline",
+  "char x=0 w=4 cols=12",
+  "char x=48 w=4 cols=12",
+  "feed line dist=48",
+]
+`;
+
+exports[`EpsonFX80 — character attributes > ESC E turns on emphasized (bold) 1`] = `
+[
+  "text "A"",
+  "text "B"",
+  "newline",
+  "char x=0 w=4 cols=12 [bold]",
+  "char x=48 w=4 cols=12 [bold]",
+  "feed line dist=48",
+]
+`;
+
+exports[`EpsonFX80 — character attributes > ESC F cancels emphasized 1`] = `
+[
+  "text "A"",
+  "text "B"",
+  "newline",
+  "char x=0 w=4 cols=12 [bold]",
+  "char x=48 w=4 cols=12",
+  "feed line dist=48",
+]
+`;
+
+exports[`EpsonFX80 — line spacing and paper motion > CR without LF does not feed the paper 1`] = `
+[
+  "line",
+  "line",
+]
+`;
+
+exports[`EpsonFX80 — line spacing and paper motion > ESC 0 / ESC 1 / ESC 2 select 1/8in, 7/72in and 1/6in feeds 1`] = `
+[
+  "text "A"",
+  "newline",
+  "char x=0 w=4 cols=12",
+  "feed line dist=0",
+  "text "B"",
+  "newline",
+  "char x=0 w=4 cols=12",
+  "feed line dist=0",
+  "text "C"",
+  "newline",
+  "char x=0 w=4 cols=12",
+  "feed line dist=0",
+]
+`;
+
+exports[`EpsonFX80 — line spacing and paper motion > form feed ejects the page 1`] = `
+[
+  "text "A"",
+  "newline",
+  "char x=0 w=4 cols=12",
+  "feed line dist=0",
+  "formfeed",
+  "feed return dist=0",
+]
+`;
+
+exports[`EpsonFX80 — pitch > SI selects condensed and SO selects one-line enlarged 1`] = `
+[
+  "text "A"",
+  "text "B"",
+  "newline",
+  "char x=0 w=4 cols=12",
+  "char x=28 w=4 cols=12",
+  "feed line dist=28",
+  "text "C"",
+  "text "D"",
+  "newline",
+  "char x=56 w=4 cols=12",
+  "char x=0 w=4 cols=12",
+  "feed line dist=0",
+]
+`;
+
+exports[`EpsonFX80 — text > advances the head one pica per character 1`] = `
+[
+  0,
+  48,
+  96,
+  144,
+]
+`;
+
+exports[`EpsonFX80 — text > prints a plain line terminated by CR LF 1`] = `
+[
+  "text "H"",
+  "text "E"",
+  "text "L"",
+  "text "L"",
+  "text "O"",
+  "newline",
+  "char x=0 w=4 cols=12",
+  "char x=48 w=4 cols=12",
+  "char x=96 w=4 cols=12",
+  "char x=144 w=4 cols=12",
+  "char x=192 w=4 cols=12",
+  "feed line dist=192",
+]
+`;

--- a/tests/js/printer/citoh.test.js
+++ b/tests/js/printer/citoh.test.js
@@ -1,0 +1,134 @@
+/*
+ * citoh.test.js - Golden tests for the C.Itoh-family printers
+ *                 (Apple DMP, ImageWriter I, ImageWriter II)
+ *
+ * All three share CItohPrinter's command parser and differ in ROM font, ribbon
+ * support and default metrics, so the suite runs the shared behaviour across
+ * every model and then pins each model's own characteristics.
+ *
+ * Written by
+ *  Mike Daley <michael_daley@icloud.com>
+ */
+
+import { describe, it, expect } from "vitest";
+import { AppleDMP } from "../../../src/js/printer/apple-dmp.js";
+import { ImageWriterI } from "../../../src/js/printer/imagewriter-i.js";
+import { ImageWriterII } from "../../../src/js/printer/imagewriter-ii.js";
+import { bytes, capture, summarise, CR, LF, FF, ESC } from "./harness.js";
+
+const MODELS = [
+  ["AppleDMP", () => new AppleDMP()],
+  ["ImageWriterI", () => new ImageWriterI()],
+  ["ImageWriterII", () => new ImageWriterII()],
+];
+
+function run(make, data) {
+  return summarise(capture(make(), bytes(...data)));
+}
+
+describe.each(MODELS)("%s — shared C.Itoh behaviour", (name, make) => {
+  it("prints a plain line terminated by CR LF", () => {
+    expect(run(make, ["HELLO", CR, LF])).toMatchSnapshot();
+  });
+
+  it("strips the Apple II high bit from character codes", () => {
+    expect(run(make, [0xc8, 0xc9, CR, LF])).toEqual(run(make, ["HI", CR, LF]));
+  });
+
+  it("ESC ! turns bold on and ESC \" turns it off", () => {
+    expect(run(make, [ESC, "!", "A", ESC, '"', "B", CR, LF])).toMatchSnapshot();
+  });
+
+  it("ESC X starts underline and ESC Y stops it", () => {
+    expect(run(make, [ESC, "X", "A", ESC, "Y", "B", CR, LF])).toMatchSnapshot();
+  });
+
+  it("ESC x / ESC y / ESC z select superscript, subscript and normal", () => {
+    expect(run(make, [ESC, "x", "A", ESC, "y", "B", ESC, "z", "C", CR, LF]))
+      .toMatchSnapshot();
+  });
+
+  it("pitch commands change the per-character advance", () => {
+    // ESC N pica (10 cpi) must advance further than ESC q condensed (15 cpi).
+    const advance = (data) => {
+      const cols = capture(make(), bytes(...data))
+        .filter((e) => e.name === "printChar")
+        .map((e) => e.data.xDot);
+      return cols[1] - cols[0];
+    };
+    expect(advance([ESC, "N", "AB", CR, LF]))
+      .toBeGreaterThan(advance([ESC, "q", "AB", CR, LF]));
+  });
+
+  it("ESC A and ESC B select 6 and 8 lines per inch", () => {
+    expect(run(make, [ESC, "A", "A", CR, LF, ESC, "B", "B", CR, LF]))
+      .toMatchSnapshot();
+  });
+
+  it("ESC > selects unidirectional printing, which slews the head home", () => {
+    // Bidirectional (the default) flips travel instead of returning, so the
+    // feed sound differs — 'return' vs 'line'.
+    const sounds = (data) =>
+      capture(make(), bytes(...data))
+        .filter((e) => e.name === "feed")
+        .map((e) => e.data.sound);
+    expect(sounds([ESC, ">", "AB", CR, LF])).toMatchSnapshot();
+    expect(sounds([ESC, "<", "AB", CR, LF])).toMatchSnapshot();
+  });
+
+  it("form feed ejects the page", () => {
+    expect(run(make, ["A", CR, LF, FF])).toMatchSnapshot();
+  });
+
+  it("ESC M selects the NLQ font, changing the cell row count", () => {
+    // NLQ cells are 18 rows against 9 for draft — a reimplementation that keeps
+    // one cell height would pass the text tests and fail here.
+    const rows = (data) =>
+      capture(make(), bytes(...data))
+        .filter((e) => e.name === "printChar")
+        .map((e) => e.data.rows);
+    expect(rows([ESC, "M", "A", CR, LF])).toMatchSnapshot();
+  });
+});
+
+describe("model identity and metrics", () => {
+  it.each(MODELS)("%s reports stable name, id and dpi", (name, make) => {
+    const p = make();
+    expect({
+      name: p.getName(),
+      id: p.getId(),
+      dpi: p.dpi,
+      cps: p.getCharsPerSecond(),
+      colorRibbon: p.supportsColorRibbon(),
+    }).toMatchSnapshot();
+  });
+});
+
+describe("ImageWriter II — colour ribbon", () => {
+  it("supports a colour ribbon where the earlier models do not", () => {
+    expect(new ImageWriterII().supportsColorRibbon()).toBe(true);
+    expect(new ImageWriterI().supportsColorRibbon()).toBe(false);
+    expect(new AppleDMP().supportsColorRibbon()).toBe(false);
+  });
+
+  it("ESC K n selects the ribbon colour band when a colour cart is loaded", () => {
+    // ESC K n takes ASCII '0'-'6'. The ribbon is the physical gate: with the
+    // default b/w cart every band maps to black, so the cart must be swapped
+    // first or this asserts nothing.
+    const colorOf = (ribbon, n) => {
+      const p = new ImageWriterII();
+      p.setRibbon(ribbon);
+      return capture(p, bytes(ESC, "K", n, "A", CR, LF))
+        .filter((e) => e.name === "printChar")
+        .map((e) => e.data.color);
+    };
+
+    // Each selectable band must resolve to a distinct ink on a colour cart.
+    const bands = ["0", "1", "2", "3", "4", "5", "6"].map((n) => colorOf("color", n));
+    expect(bands.flat()).toMatchSnapshot();
+
+    // A black cart overrides the selection — colour data still prints black.
+    expect(colorOf("bw", "1")).toEqual(["black"]);
+    expect(colorOf("color", "1")).not.toEqual(["black"]);
+  });
+});

--- a/tests/js/printer/epson-fx80.test.js
+++ b/tests/js/printer/epson-fx80.test.js
@@ -1,0 +1,126 @@
+/*
+ * epson-fx80.test.js - Golden tests for the Epson FX-80 emulation
+ *
+ * Written by
+ *  Mike Daley <michael_daley@icloud.com>
+ */
+
+import { describe, it, expect } from "vitest";
+import { EpsonFX80 } from "../../../src/js/printer/epson-fx80.js";
+import { bytes, capture, summarise, CR, LF, FF, SI, SO, ESC } from "./harness.js";
+
+/** A fresh printer per case — these are stateful machines. */
+function fx80() {
+  return new EpsonFX80();
+}
+
+function run(data) {
+  return summarise(capture(fx80(), bytes(...data)));
+}
+
+describe("EpsonFX80 — text", () => {
+  it("prints a plain line terminated by CR LF", () => {
+    expect(run(["HELLO", CR, LF])).toMatchSnapshot();
+  });
+
+  it("advances the head one pica per character", () => {
+    // Column positions are the load-bearing part here: each glyph must land a
+    // fixed advance further right than the last.
+    const events = capture(fx80(), bytes("ABCD", CR, LF));
+    const columns = events
+      .filter((e) => e.name === "printChar")
+      .map((e) => e.data.xDot);
+    expect(columns).toMatchSnapshot();
+  });
+
+  it("strips the Apple II high bit from character codes", () => {
+    // The card delivers ASCII with bit 7 set; "HI" and "HI"|0x80 must print
+    // identically.
+    const plain = run(["HI", CR, LF]);
+    const highBit = run([0xc8, 0xc9, CR, LF]);
+    expect(highBit).toEqual(plain);
+  });
+});
+
+describe("EpsonFX80 — character attributes", () => {
+  it("ESC E turns on emphasized (bold)", () => {
+    expect(run([ESC, "E", "AB", CR, LF])).toMatchSnapshot();
+  });
+
+  it("ESC F cancels emphasized", () => {
+    expect(run([ESC, "E", "A", ESC, "F", "B", CR, LF])).toMatchSnapshot();
+  });
+
+  it("ESC - 1 turns on underline, ESC - 0 turns it off", () => {
+    expect(run([ESC, "-", 1, "A", ESC, "-", 0, "B", CR, LF])).toMatchSnapshot();
+  });
+
+  it("ESC 4 turns on italic, ESC 5 cancels it", () => {
+    expect(run([ESC, "4", "A", ESC, "5", "B", CR, LF])).toMatchSnapshot();
+  });
+});
+
+describe("EpsonFX80 — pitch", () => {
+  it("SI selects condensed and SO selects one-line enlarged", () => {
+    expect(run([SI, "AB", CR, LF, SO, "CD", CR, LF])).toMatchSnapshot();
+  });
+
+  it("condensed narrows the per-character advance", () => {
+    const advance = (data) => {
+      const cols = capture(fx80(), bytes(...data))
+        .filter((e) => e.name === "printChar")
+        .map((e) => e.data.xDot);
+      return cols[1] - cols[0];
+    };
+    expect(advance(["AB", CR, LF])).toBeGreaterThan(advance([SI, "AB", CR, LF]));
+  });
+});
+
+describe("EpsonFX80 — line spacing and paper motion", () => {
+  it("ESC 0 / ESC 1 / ESC 2 select 1/8in, 7/72in and 1/6in feeds", () => {
+    expect(run([ESC, "0", "A", CR, LF, ESC, "1", "B", CR, LF, ESC, "2", "C", CR, LF]))
+      .toMatchSnapshot();
+  });
+
+  it("form feed ejects the page", () => {
+    expect(run(["A", CR, LF, FF])).toMatchSnapshot();
+  });
+
+  it("CR without LF does not feed the paper", () => {
+    // Auto-LF off: the next pass overprints the same band.
+    const feeds = capture(fx80(), bytes("A", CR, "B", CR, LF))
+      .filter((e) => e.name === "feed")
+      .map((e) => e.data.sound);
+    expect(feeds).toMatchSnapshot();
+  });
+});
+
+describe("EpsonFX80 — bit-image graphics", () => {
+  it("ESC K emits one dot column per data byte", () => {
+    // ESC K n1 n2 <n1+256*n2 columns>. Four columns with distinct pin patterns.
+    expect(run([ESC, "K", 4, 0, 0x01, 0x81, 0xff, 0x00, CR, LF])).toMatchSnapshot();
+  });
+
+  it("ESC K reverses Epson MSB-is-top into renderer bit-0-is-top order", () => {
+    // 0x01 has only the LSB set on the wire, which is the BOTTOM pin, so the
+    // renderer must see it at bit 7. This is the wire-order convention that a
+    // reimplementation is most likely to get backwards.
+    const dots = capture(fx80(), bytes(ESC, "K", 1, 0, 0x01, CR, LF))
+      .filter((e) => e.name === "printDots")
+      .map((e) => e.data.byte);
+    expect(dots).toEqual([0x80]);
+  });
+
+  it("ESC ^ nine-pin graphics carries pin 9 from the second byte", () => {
+    // Pins 1-8 from byte1, pin 9 from bit 7 of byte2 — pin 9 lands at bit 8.
+    const dots = capture(fx80(), bytes(ESC, "^", 0, 1, 0, 0x00, 0x80, CR, LF))
+      .filter((e) => e.name === "printDots")
+      .map((e) => e.data.byte);
+    expect(dots).toEqual([0x100]);
+  });
+
+  it("a zero-length graphics run consumes no data bytes", () => {
+    // ESC K 0 0 must return to normal parsing, so "AB" prints as text.
+    expect(run([ESC, "K", 0, 0, "AB", CR, LF])).toMatchSnapshot();
+  });
+});

--- a/tests/js/printer/harness.js
+++ b/tests/js/printer/harness.js
@@ -1,0 +1,161 @@
+/*
+ * harness.js - Golden-test harness for the JS printer emulation
+ *
+ * The printers are pure state machines: bytes go in via receiveByte(), and the
+ * emulation's entire observable output leaves through the event sink as an
+ * ordered stream of {name, data, dt} records. PrinterBase.setEventSink() is
+ * documented as the headless path ("Without a sink, events fire in order
+ * immediately"), so capturing there gets the full behaviour with no DOM, no
+ * canvas and no scheduler.
+ *
+ * These are characterization tests: they pin what the code does today so that
+ * refactoring — or a future port out of JavaScript — has to reproduce it
+ * exactly, or show the difference as a deliberate snapshot edit.
+ *
+ * Written by
+ *  Mike Daley <michael_daley@icloud.com>
+ */
+
+/**
+ * Build a byte array from a mix of strings and numeric literals.
+ *
+ *   bytes("HI", CR, LF)            → [72, 73, 13, 10]
+ *   bytes(ESC, "E", "Bold")        → [27, 69, 66, 111, 108, 100]
+ *
+ * Strings contribute their char codes; numbers are emitted verbatim; nested
+ * arrays are flattened so callers can splice in generated graphics data.
+ */
+export function bytes(...parts) {
+  const out = [];
+  for (const part of parts) {
+    if (typeof part === "string") {
+      for (let i = 0; i < part.length; i++) out.push(part.charCodeAt(i));
+    } else if (Array.isArray(part)) {
+      out.push(...bytes(...part));
+    } else {
+      out.push(part & 0xff);
+    }
+  }
+  return out;
+}
+
+// Common control codes, named so the test bodies read like a print job.
+export const NUL = 0x00;
+export const BS = 0x08;
+export const HT = 0x09;
+export const LF = 0x0a;
+export const VT = 0x0b;
+export const FF = 0x0c;
+export const CR = 0x0d;
+export const SO = 0x0e;
+export const SI = 0x0f;
+export const ESC = 0x1b;
+
+/**
+ * Round every number in a structure to `places` decimals.
+ *
+ * Timings (dt) and dot pitches are computed from divisions like dpi/10 and
+ * carriage velocities, so they carry floating-point noise that would otherwise
+ * make snapshots fail for reasons unrelated to behaviour.
+ */
+function roundDeep(value, places) {
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) return value;
+    const f = 10 ** places;
+    // +0 normalises -0, which serialises differently from 0.
+    return Math.round(value * f) / f + 0;
+  }
+  if (Array.isArray(value)) return value.map((v) => roundDeep(v, places));
+  if (value && typeof value === "object") {
+    const out = {};
+    for (const key of Object.keys(value).sort()) {
+      out[key] = roundDeep(value[key], places);
+    }
+    return out;
+  }
+  return value;
+}
+
+// Events that PrinterBase.emit() passes straight to _fire() rather than
+// buffering into the line. These never reach the event sink, so the harness has
+// to subscribe to them separately to see the whole picture.
+const PASSTHROUGH_EVENTS = [
+  "text",
+  "newline",
+  "linefeed",
+  "carriagereturn",
+  "formfeed",
+  "backspace",
+];
+
+/**
+ * Feed a byte stream to a printer and return its normalised event stream.
+ *
+ * The emulation has two output paths and both matter:
+ *   - strikes and feeds are buffered, ordered by the head, and released through
+ *     the event sink with a travel time (dt);
+ *   - text and line-terminator notifications fire immediately through the
+ *     listener path.
+ * Both are captured into one array in call order, so the snapshot preserves the
+ * real interleaving (a "newline" listener call happens before the strikes that
+ * line committed).
+ *
+ * @param {object} printer  A PrinterBase subclass instance
+ * @param {number[]} data   Bytes as they would arrive from the interface card
+ * @param {object} [opts]
+ * @param {number} [opts.places=4]  Decimal places to round numbers to
+ * @returns {Array<{name: string, data: *, dt?: number}>}
+ */
+export function capture(printer, data, opts = {}) {
+  const places = opts.places ?? 4;
+  const events = [];
+
+  printer.setEventSink((event) => events.push(roundDeep(event, places)));
+
+  for (const name of PASSTHROUGH_EVENTS) {
+    printer.on(name, (payload) => events.push(roundDeep({ name, data: payload }, places)));
+  }
+
+  for (const byte of data) printer.receiveByte(byte);
+
+  // Strikes buffered on the current line are only committed on a line
+  // terminator; without this a job not ending in CR/LF would snapshot as empty.
+  printer.flushLine();
+
+  return events;
+}
+
+/**
+ * Condense an event stream to a compact, human-reviewable form.
+ *
+ * Full event records are verbose enough that a real regression can hide in the
+ * diff. This keeps the shape of the job — what struck the paper, in what order,
+ * at which column — which is what these tests are actually asserting about.
+ */
+export function summarise(events) {
+  return events.map((e) => {
+    const d = e.data || {};
+    switch (e.name) {
+      case "printChar": {
+        // printChar carries no character code — the glyph is the column data,
+        // and the readable character arrives separately as a "text" event.
+        const attrs = [
+          d.bold ? "bold" : null,
+          d.italic ? "italic" : null,
+          d.underline ? "underline" : null,
+          d.script && d.script !== "none" ? d.script : null,
+        ].filter(Boolean);
+        return `char x=${d.xDot} w=${d.dotW} cols=${(d.cols || []).length}` +
+          (attrs.length ? ` [${attrs.join(",")}]` : "");
+      }
+      case "printDots":
+        return `dots 0b${(d.byte ?? 0).toString(2).padStart(9, "0")} x=${d.xDot} w=${d.dotW}`;
+      case "feed":
+        return `feed ${d.sound} dist=${d.dist}`;
+      case "text":
+        return `text ${JSON.stringify(String(e.data ?? ""))}`;
+      default:
+        return e.name;
+    }
+  });
+}

--- a/tests/unit/test_debug_log.cpp
+++ b/tests/unit/test_debug_log.cpp
@@ -1,0 +1,97 @@
+/*
+ * test_debug_log.cpp - Tests for the host-installed debug log sink
+ *
+ * Written by
+ *  Mike Daley <michael_daley@icloud.com>
+ */
+
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+
+#include "debug/debug_log.hpp"
+
+#include <string>
+#include <vector>
+
+namespace {
+
+std::vector<std::string> g_captured;
+
+void captureSink(const char *message) { g_captured.emplace_back(message); }
+
+// Restores the global sink so one test's installation cannot leak into the
+// next — the sink is process-wide by design.
+struct SinkGuard {
+  SinkGuard() { g_captured.clear(); }
+  ~SinkGuard() { a2e::setDebugLogSink(nullptr); g_captured.clear(); }
+};
+
+} // namespace
+
+TEST_CASE("no sink installed", "[debug_log]") {
+  SinkGuard guard;
+
+  REQUIRE_FALSE(a2e::hasDebugLogSink());
+
+  // Must be safe, and must not crash on format specifiers it never expands.
+  a2e::debugLog("dropped %d", 42);
+  REQUIRE(g_captured.empty());
+}
+
+TEST_CASE("installed sink receives formatted messages", "[debug_log]") {
+  SinkGuard guard;
+  a2e::setDebugLogSink(captureSink);
+
+  REQUIRE(a2e::hasDebugLogSink());
+
+  a2e::debugLog("VIA%d: ctrl %d->%d ORA=0x%X", 1, 0, 7, 0xAB);
+
+  REQUIRE(g_captured.size() == 1);
+  REQUIRE(g_captured[0] == "VIA1: ctrl 0->7 ORA=0xAB");
+}
+
+TEST_CASE("messages arrive in order", "[debug_log]") {
+  SinkGuard guard;
+  a2e::setDebugLogSink(captureSink);
+
+  a2e::debugLog("first");
+  a2e::debugLog("second");
+  a2e::debugLog("third");
+
+  REQUIRE(g_captured == std::vector<std::string>{"first", "second", "third"});
+}
+
+TEST_CASE("sink can be replaced and cleared", "[debug_log]") {
+  SinkGuard guard;
+
+  a2e::setDebugLogSink(captureSink);
+  a2e::debugLog("kept");
+
+  a2e::setDebugLogSink(nullptr);
+  a2e::debugLog("dropped");
+
+  REQUIRE(a2e::hasDebugLogSink() == false);
+  REQUIRE(g_captured == std::vector<std::string>{"kept"});
+}
+
+TEST_CASE("a null format string is ignored", "[debug_log]") {
+  SinkGuard guard;
+  a2e::setDebugLogSink(captureSink);
+
+  a2e::debugLog(nullptr);
+
+  REQUIRE(g_captured.empty());
+}
+
+TEST_CASE("over-long messages are truncated, not overflowed", "[debug_log]") {
+  SinkGuard guard;
+  a2e::setDebugLogSink(captureSink);
+
+  // The sink formats into a fixed 512-byte buffer; this is deliberately longer.
+  const std::string huge(2000, 'x');
+  a2e::debugLog("%s", huge.c_str());
+
+  REQUIRE(g_captured.size() == 1);
+  REQUIRE(g_captured[0].size() < huge.size());
+  REQUIRE(g_captured[0].find_first_not_of('x') == std::string::npos);
+}

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+
+// Deliberately separate from vite.config.js: the app build config carries
+// manualChunks and asset rules that have nothing to do with the test run, and
+// merging the two makes failures harder to read.
+export default defineConfig({
+  test: {
+    include: ["tests/js/**/*.test.js"],
+    // The printer emulation and the other modules under test are pure logic —
+    // no DOM, no canvas — so plain node is enough. Anything that grows a DOM
+    // dependency should be treated as a smell rather than a reason to add jsdom.
+    environment: "node",
+  },
+});


### PR DESCRIPTION
Groundwork so misplaced logic can be moved safely, and so this class of problem cannot silently accumulate again. Three independent pieces; none changes emulation behaviour.

## Vitest + printer golden tests

The JS side had no test runner at all. Adds vitest with a separate `vitest.config.js` — merging with the app build config only makes failures harder to read.

The printers are the largest untested subsystem and are staying in JS, so they get characterization coverage in place: FX-80, Apple DMP, ImageWriter I and II. **51 tests, 43 snapshots.**

Two things made this cheap: `PrinterBase.setEventSink()` is already documented as the headless path, and the emulation is entirely DOM-free (every `canvas` match is a comment or a method name). So the harness runs in plain node with no shims. It records both output paths — sink-timed strikes and the immediate listener notifications — in call order, since the interleaving is part of the behaviour.

Coverage is weighted toward what a reimplementation gets wrong rather than what is easy to assert:

- bit-image wire order (Epson MSB-is-top vs the renderer's bit-0-is-top)
- nine-pin graphics carrying pin 9 in the second byte's bit 7
- NLQ's 18-row cells vs draft's 9
- bidirectional vs unidirectional head return
- the ribbon gating colour selection

That last one is worth calling out: the first version asserted `ESC K` colour select and snapshotted `["black"]` — passing while proving nothing, because the default cart is monochrome. It now loads a colour cart first, pins all seven bands, and asserts that a b/w cart overrides the selection.

## check-exports.sh

`EXPORTED_FUNCTIONS` in `CMakeLists.txt` is 259 hand-maintained entries that nothing verified. Catches drift both ways:

- a `EMSCRIPTEN_KEEPALIVE` function missing from the list is dead-stripped by the linker and fails at runtime;
- a listed name with no definition is a stale entry.

Currently in sync.

## check-core-purity.sh + `a2e::debugLog`

`src/core/` had five `EM_ASM` `console.log` sites in `via6522.cpp` and `ay8910.cpp`, so the emulation core depended on a browser and the native test binaries silently lost the logging.

Debug output now formats into a host-installed sink (`src/core/debug/debug_log.hpp`); the WASM binding wires it to `console.log`, which is the platform layer's job. The capability is preserved, not deleted. A side effect is that the pre-existing `prevControl` unused-variable warning is gone.

The check matches code rather than prose, so documentation may still name the thing it warns about.

## Both checks are verified to fail

A check that cannot fail is worse than none. Each was confirmed by injecting the condition it guards — a stale export, a missing export, and an `#ifdef __EMSCRIPTEN__` in the core — observing the failure, and reverting.

Wired up as `npm run check`, which runs both checks and the JS tests.

## Testing

- C++: 39/39 (was 38 — adds `test_debug_log`, 6 cases covering the sink including truncation and null-format handling)
- JS: 51/51
- WASM builds clean; `npm run check` green

## Note

There is no `.github/` in the repo, so `npm run check` is the entry point rather than a CI workflow. Happy to add one if these should be enforced on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)