### PR TITLE
fix: joystick button remapping

### DIFF
--- a/src/js/input/input-handler.js
+++ b/src/js/input/input-handler.js
@@ -118,6 +118,30 @@ export class InputHandler {
       return;
     }
 
+    // Joystick buttons: Left Alt → Button 0 (Open Apple), Right Alt → Button 1 (Closed Apple)
+    if (keyCode === 18 && !ctrl && !meta) {
+      const loc = event.location || 0;
+      if (loc === 1 || loc === 0) {
+        // Left Alt or unknown → Button 0
+        event.preventDefault();
+        this.wasmModule._setButton(0, true);
+        this.wasmModule._handleRawKeyDown(18, shift, ctrl, alt, meta, capsLock);
+        return;
+      }
+      if (loc === 2) {
+        // Right Alt → Button 1
+        event.preventDefault();
+        this.wasmModule._setButton(1, true);
+        this.wasmModule._handleRawKeyDown(91, shift, ctrl, alt, meta, capsLock);
+        return;
+      }
+    }
+    // Win / Context Menu → block, do nothing
+    if (keyCode === 91 || keyCode === 93) {
+      event.preventDefault();
+      return;
+    }
+
     // Prevent default for these keys when not using modifiers
     if (this.shouldPreventDefault(event)) {
       event.preventDefault();
@@ -147,6 +171,25 @@ export class InputHandler {
     const ctrl = event.ctrlKey;
     const alt = event.altKey;
     const meta = event.metaKey;
+
+    // Release joystick buttons
+    if (keyCode === 18) {
+      const loc = event.location || 0;
+      if (loc === 1 || loc === 0) {
+        this.wasmModule._setButton(0, false);
+        this.wasmModule._handleRawKeyUp(18, shift, ctrl, alt, meta);
+        return;
+      }
+      if (loc === 2) {
+        this.wasmModule._setButton(1, false);
+        this.wasmModule._handleRawKeyUp(91, shift, ctrl, alt, meta);
+        return;
+      }
+    }
+    // Win / Context Menu → ignore release
+    if (keyCode === 91 || keyCode === 93) {
+      return;
+    }
 
     // Check if cursor keys should act as joystick
     if (this.joystickWindow && this.joystickWindow.handleCursorKey(keyCode, false)) {


### PR DESCRIPTION
## Problem

The current joystick button mapping has two issues:

1. **Both Left and Right Alt map to Button 0 (Open Apple)** — `keyCode 18` is identical for both sides, and `event.key` returns `"Alt"` for both on US keyboards (only European/AltGr layouts return `"AltGraph"`). So Right Alt cannot currently be used for Button 1.

2. **Windows/Context Menu keys are mapped to Button 1 (Closed Apple)** — `keyCode 91` (Win) and `keyCode 93` (Context Menu) are intercepted by the OS before the browser can handle them, making them unreliable as game buttons. The Win key opens the Start Menu; Context Menu opens a right-click menu.

## Solution

Intercept Alt key events in JavaScript (`src/js/input/input-handler.js`) using `event.location` before they reach WASM:

| Key | Condition | Maps to |
|-----|-----------|---------|
| Left Alt | `keyCode 18`, `location === 1 \|\| 0` | **Button 0 (Open Apple)** |
| Right Alt | `keyCode 18`, `location === 2` | **Button 1 (Closed Apple)** |
| Win / Context Menu | `keyCode 91 / 93` | **blocked, does nothing** |

This approach:
- Calls both `_setButton()` and `_handleRawKeyDown()` to keep the C++ keyboard flags in sync
- Requires **no WASM rebuild** — only the JS layer changes
- Uses `event.location` which is reliable across all browsers (1=left, 2=right)

## Rationale

This matches the standard convention used by other Apple II emulators:

| Emulator | Button 0 (Open Apple) | Button 1 (Closed Apple) |
|----------|----------------------|------------------------|
| [**AppleWin**](https://github.com/AppleWin/AppleWin) (Windows) | Left Alt | Right Alt |
| [**Apple2TS**](https://github.com/ct6502/apple2ts) (TypeScript) | Left Alt | Right Alt |

I'm also a contributor to **Apple2TS** (helped complete i18n and joystick key implementation), where the same left/right Alt mapping applies, so I'm familiar with the convention across emulators.

The original Alt→Button 0 and Win→Button 1 mapping was unique to this emulator and caused issues on real hardware where users expect the AppleWin behavior.

## Testing

Verified manually by pressing each Alt key and checking button state via the Joystick window UI. No regressions in regular keyboard input.

Best,
anomixer
