### PR TITLE
Phase C1: extract Applesoft variable primitives into the core

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ set(CORE_SOURCES
     src/core/cards/softcard/z80/z80_opcodes_ddcb.cpp
     src/core/cards/softcard/z80/z80_opcodes_fdcb.cpp
     src/core/noslot_clock.cpp
+    src/core/basic/applesoft_vars.cpp
     src/core/debug/condition_evaluator.cpp
     src/core/filesystem/dos33.cpp
     src/core/filesystem/prodos.cpp
@@ -457,6 +458,7 @@ else()
         src/core/cards/softcard/z80/z80_opcodes_ddcb.cpp
         src/core/cards/softcard/z80/z80_opcodes_fdcb.cpp
         src/core/noslot_clock.cpp
+        src/core/basic/applesoft_vars.cpp
         src/core/debug/condition_evaluator.cpp
         src/core/filesystem/dos33.cpp
         src/core/filesystem/prodos.cpp
@@ -783,6 +785,12 @@ else()
     add_catch2_test(test_debug_log
         tests/unit/test_debug_log.cpp
         src/core/debug/debug_log.cpp
+    )
+
+    # Applesoft variable representation (only applesoft_vars.cpp)
+    add_catch2_test(test_applesoft_vars
+        tests/unit/test_applesoft_vars.cpp
+        src/core/basic/applesoft_vars.cpp
     )
 
 endif()

--- a/src/core/basic/applesoft_vars.cpp
+++ b/src/core/basic/applesoft_vars.cpp
@@ -1,0 +1,120 @@
+/*
+ * applesoft_vars.cpp - Applesoft variable representation primitives
+ *
+ * Written by
+ *  Mike Daley <michael_daley@icloud.com>
+ */
+
+#include "applesoft_vars.hpp"
+
+#include <cmath>
+
+namespace a2e {
+
+double ApplesoftVars::decodeFloat(const uint8_t bytes[APPLESOFT_FLOAT_SIZE]) {
+  const uint8_t exp = bytes[0];
+
+  // A zero exponent is Applesoft's representation of zero; the mantissa bytes
+  // are not meaningful in that case.
+  if (exp == 0) return 0.0;
+
+  const double sign = (bytes[1] & 0x80) ? -1.0 : 1.0;
+
+  // Normalized 1.xxxx form: the leading 1 is implied, so start there and add
+  // the stored fraction bits. Bit 7 of the first mantissa byte is the sign, so
+  // only its low 7 bits contribute.
+  double mantissa = 1.0;
+  mantissa += (bytes[1] & 0x7F) / 128.0;
+  mantissa += bytes[2] / 32768.0;
+  mantissa += bytes[3] / 8388608.0;
+  mantissa += bytes[4] / 2147483648.0;
+
+  // Excess-129: the implied 1 sits at 2^-1 rather than 2^0.
+  return sign * mantissa * std::pow(2.0, static_cast<int>(exp) - 129);
+}
+
+void ApplesoftVars::encodeFloat(double value, uint8_t out[APPLESOFT_FLOAT_SIZE]) {
+  for (int i = 0; i < APPLESOFT_FLOAT_SIZE; i++) out[i] = 0;
+
+  // Zero, and anything not finite, is stored as Applesoft zero.
+  if (value == 0.0 || !std::isfinite(value)) return;
+
+  const int sign = value < 0.0 ? 1 : 0;
+  double abs = std::fabs(value);
+
+  // Normalise so that 1.0 <= mantissa < 2.0.
+  int exp = static_cast<int>(std::floor(std::log2(abs)));
+  double mantissa = abs / std::pow(2.0, exp);
+
+  // log2 is not exact at powers of two, so nudge the result back into range.
+  if (mantissa < 1.0) { mantissa *= 2.0; exp--; }
+  if (mantissa >= 2.0) { mantissa /= 2.0; exp++; }
+
+  const int expByte = exp + 129;
+  if (expByte <= 0 || expByte > 255) return; // under/overflow -> zero
+
+  out[0] = static_cast<uint8_t>(expByte);
+
+  // Drop the implied leading 1 and spread 31 fraction bits over bytes 1..4.
+  // Byte 1 holds 7 fraction bits with the sign in bit 7.
+  mantissa -= 1.0;
+
+  mantissa *= 128.0;
+  out[1] = static_cast<uint8_t>((static_cast<int>(std::floor(mantissa)) & 0x7F) | (sign << 7));
+  mantissa -= std::floor(mantissa);
+
+  mantissa *= 256.0;
+  out[2] = static_cast<uint8_t>(static_cast<int>(std::floor(mantissa)) & 0xFF);
+  mantissa -= std::floor(mantissa);
+
+  mantissa *= 256.0;
+  out[3] = static_cast<uint8_t>(static_cast<int>(std::floor(mantissa)) & 0xFF);
+  mantissa -= std::floor(mantissa);
+
+  mantissa *= 256.0;
+  out[4] = static_cast<uint8_t>(static_cast<int>(std::lround(mantissa)) & 0xFF);
+}
+
+void ApplesoftVars::parseName(uint8_t byte1, uint8_t byte2, char *outName,
+                              BasicVarType *outType) {
+  const char char1 = static_cast<char>(byte1 & 0x7F);
+  const char char2 = static_cast<char>(byte2 & 0x7F);
+
+  const bool isInteger = (byte1 & 0x80) != 0 && (byte2 & 0x80) != 0;
+  const bool isString = !isInteger && (byte2 & 0x80) != 0;
+
+  BasicVarType type = BasicVarType::Real;
+  char suffix = '\0';
+  if (isInteger) {
+    type = BasicVarType::Integer;
+    suffix = '%';
+  } else if (isString) {
+    type = BasicVarType::String;
+    suffix = '$';
+  }
+
+  int n = 0;
+  outName[n++] = char1;
+  if (char2 != '\0') outName[n++] = char2; // one-character names pad with NUL
+  if (suffix != '\0') outName[n++] = suffix;
+  outName[n] = '\0';
+
+  if (outType) *outType = type;
+}
+
+int ApplesoftVars::elementSize(BasicVarType type) {
+  switch (type) {
+  case BasicVarType::Integer: return 2; // high, low
+  case BasicVarType::String:  return 3; // length, pointer low, pointer high
+  case BasicVarType::Real:    return APPLESOFT_FLOAT_SIZE;
+  }
+  return APPLESOFT_FLOAT_SIZE;
+}
+
+int32_t ApplesoftVars::decodeInteger(uint8_t high, uint8_t low) {
+  int32_t value = (static_cast<int32_t>(high) << 8) | low;
+  if (value >= 0x8000) value -= 0x10000; // two's complement
+  return value;
+}
+
+} // namespace a2e

--- a/src/core/basic/applesoft_vars.hpp
+++ b/src/core/basic/applesoft_vars.hpp
@@ -1,0 +1,73 @@
+/*
+ * applesoft_vars.hpp - Applesoft variable representation primitives
+ *
+ * Applesoft stores variables in a fixed layout: a two-byte name whose high bits
+ * carry the type, then a value that is a 5-byte MBF float, a 2-byte big-endian
+ * integer, or a length-plus-pointer string descriptor.
+ *
+ * That knowledge had accumulated in three places — the condition evaluator (for
+ * breakpoint expressions) and the debugger's variable inspector in JavaScript,
+ * which also owned the only float *encoder*. This is the single home for it.
+ *
+ * These functions are pure: they take bytes and return values, with no
+ * dependency on Emulator or on any memory-reading interface, which keeps them
+ * directly testable and usable from every caller.
+ *
+ * Written by
+ *  Mike Daley <michael_daley@icloud.com>
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace a2e {
+
+/** Applesoft variable types, as encoded in the high bits of the name bytes. */
+enum class BasicVarType { Real, Integer, String };
+
+/** Bytes in an Applesoft MBF float: 1 exponent + 4 mantissa. */
+inline constexpr int APPLESOFT_FLOAT_SIZE = 5;
+
+/** Longest printable name: two characters plus a `%` or `$` suffix, plus NUL. */
+inline constexpr int APPLESOFT_NAME_MAX = 4;
+
+class ApplesoftVars {
+public:
+  /**
+   * Decode a 5-byte Applesoft float.
+   *
+   * Excess-129 exponent with an implied leading 1 in the mantissa, and the sign
+   * in bit 7 of the first mantissa byte. A zero exponent means the value is
+   * zero regardless of the mantissa.
+   */
+  static double decodeFloat(const uint8_t bytes[APPLESOFT_FLOAT_SIZE]);
+
+  /**
+   * Encode a double into Applesoft's 5-byte float.
+   *
+   * Values that cannot be represented — zero, and anything that under- or
+   * overflows the excess-129 exponent — are written as Applesoft zero (all
+   * bytes zero), which is what the interpreter itself stores.
+   */
+  static void encodeFloat(double value, uint8_t out[APPLESOFT_FLOAT_SIZE]);
+
+  /**
+   * Decode the two name bytes of a variable or array entry.
+   *
+   * The type lives in the high bits: both set is an integer, only the second
+   * set is a string, neither is a real. `outName` receives the printable name
+   * including its `%` or `$` suffix and must have room for APPLESOFT_NAME_MAX
+   * bytes. A zero second character means a one-character name.
+   */
+  static void parseName(uint8_t byte1, uint8_t byte2, char *outName,
+                        BasicVarType *outType);
+
+  /** Bytes each element of this type occupies inside an array's data area. */
+  static int elementSize(BasicVarType type);
+
+  /** Decode a 2-byte big-endian Applesoft integer as signed. */
+  static int32_t decodeInteger(uint8_t high, uint8_t low);
+};
+
+} // namespace a2e

--- a/src/core/debug/condition_evaluator.cpp
+++ b/src/core/debug/condition_evaluator.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "condition_evaluator.hpp"
+#include "../basic/applesoft_vars.hpp"
 #include "../emulator.hpp"
 #include <cctype>
 #include <cmath>
@@ -13,21 +14,15 @@
 
 namespace a2e {
 
-// Decode 5-byte Applesoft float to int32_t (truncated)
+// Read a 5-byte Applesoft float out of memory and truncate toward zero.
+// The decoding itself lives in ApplesoftVars so the debugger's variable
+// inspector and this evaluator cannot drift apart.
 static int32_t decodeApplesoftFloat(const Emulator& emu, uint16_t addr) {
-  uint8_t exp = emu.peekMemory(addr);
-  if (exp == 0) return 0;
-
-  int sign = (emu.peekMemory(addr + 1) & 0x80) ? -1 : 1;
-  double mantissa = 1.0;
-  mantissa += (emu.peekMemory(addr + 1) & 0x7F) / 128.0;
-  mantissa += emu.peekMemory(addr + 2) / 32768.0;
-  mantissa += emu.peekMemory(addr + 3) / 8388608.0;
-  mantissa += emu.peekMemory(addr + 4) / 2147483648.0;
-
-  int actualExp = exp - 129;
-  double value = sign * mantissa * pow(2.0, actualExp);
-  return static_cast<int32_t>(value);
+  uint8_t bytes[APPLESOFT_FLOAT_SIZE];
+  for (int i = 0; i < APPLESOFT_FLOAT_SIZE; i++) {
+    bytes[i] = emu.peekMemory(static_cast<uint16_t>(addr + i));
+  }
+  return static_cast<int32_t>(ApplesoftVars::decodeFloat(bytes));
 }
 
 // Read a BASIC simple variable value by its encoded name bytes

--- a/tests/unit/test_applesoft_vars.cpp
+++ b/tests/unit/test_applesoft_vars.cpp
@@ -1,0 +1,180 @@
+/*
+ * test_applesoft_vars.cpp - Tests for Applesoft variable representation
+ *
+ * Written by
+ *  Mike Daley <michael_daley@icloud.com>
+ */
+
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+
+#include "basic/applesoft_vars.hpp"
+
+#include <cmath>
+#include <cstring>
+#include <string>
+
+using namespace a2e;
+
+namespace {
+
+/** Build a float byte array literally, for asserting against known encodings. */
+struct Float5 {
+  uint8_t b[APPLESOFT_FLOAT_SIZE];
+  Float5(uint8_t e, uint8_t m1, uint8_t m2, uint8_t m3, uint8_t m4)
+      : b{e, m1, m2, m3, m4} {}
+};
+
+std::string nameOf(uint8_t b1, uint8_t b2, BasicVarType *type = nullptr) {
+  char buf[APPLESOFT_NAME_MAX];
+  BasicVarType t;
+  ApplesoftVars::parseName(b1, b2, buf, &t);
+  if (type) *type = t;
+  return std::string(buf);
+}
+
+} // namespace
+
+// ============================================================================
+// Float decoding
+// ============================================================================
+
+TEST_CASE("decodeFloat known encodings", "[applesoft][float]") {
+  // Exponent is excess-129 with an implied leading 1, so $81 means 2^0.
+  CHECK(ApplesoftVars::decodeFloat(Float5(0x81, 0x00, 0x00, 0x00, 0x00).b) == Approx(1.0));
+  CHECK(ApplesoftVars::decodeFloat(Float5(0x81, 0x80, 0x00, 0x00, 0x00).b) == Approx(-1.0));
+  CHECK(ApplesoftVars::decodeFloat(Float5(0x80, 0x00, 0x00, 0x00, 0x00).b) == Approx(0.5));
+  CHECK(ApplesoftVars::decodeFloat(Float5(0x82, 0x00, 0x00, 0x00, 0x00).b) == Approx(2.0));
+
+  // 10.0 = 1.25 * 2^3 -> exponent 3+129 = $84, fraction 0.25 -> 0.25*128 = $20
+  CHECK(ApplesoftVars::decodeFloat(Float5(0x84, 0x20, 0x00, 0x00, 0x00).b) == Approx(10.0));
+}
+
+TEST_CASE("decodeFloat treats a zero exponent as zero", "[applesoft][float]") {
+  // The mantissa is deliberately non-zero: a zero exponent wins regardless.
+  CHECK(ApplesoftVars::decodeFloat(Float5(0x00, 0xFF, 0xFF, 0xFF, 0xFF).b) == 0.0);
+}
+
+TEST_CASE("decodeFloat carries the sign from mantissa bit 7", "[applesoft][float]") {
+  const double positive = ApplesoftVars::decodeFloat(Float5(0x84, 0x20, 0x00, 0x00, 0x00).b);
+  const double negative = ApplesoftVars::decodeFloat(Float5(0x84, 0xA0, 0x00, 0x00, 0x00).b);
+
+  CHECK(positive == Approx(10.0));
+  CHECK(negative == Approx(-10.0));
+}
+
+// ============================================================================
+// Float encoding
+// ============================================================================
+
+TEST_CASE("encodeFloat produces the canonical encodings", "[applesoft][float]") {
+  uint8_t out[APPLESOFT_FLOAT_SIZE];
+
+  ApplesoftVars::encodeFloat(1.0, out);
+  CHECK(memcmp(out, Float5(0x81, 0x00, 0x00, 0x00, 0x00).b, APPLESOFT_FLOAT_SIZE) == 0);
+
+  ApplesoftVars::encodeFloat(-1.0, out);
+  CHECK(memcmp(out, Float5(0x81, 0x80, 0x00, 0x00, 0x00).b, APPLESOFT_FLOAT_SIZE) == 0);
+
+  ApplesoftVars::encodeFloat(10.0, out);
+  CHECK(memcmp(out, Float5(0x84, 0x20, 0x00, 0x00, 0x00).b, APPLESOFT_FLOAT_SIZE) == 0);
+}
+
+TEST_CASE("encodeFloat writes Applesoft zero for zero", "[applesoft][float]") {
+  uint8_t out[APPLESOFT_FLOAT_SIZE];
+  ApplesoftVars::encodeFloat(0.0, out);
+
+  for (int i = 0; i < APPLESOFT_FLOAT_SIZE; i++) CHECK(out[i] == 0);
+}
+
+TEST_CASE("encodeFloat clamps out-of-range magnitudes to zero", "[applesoft][float]") {
+  uint8_t out[APPLESOFT_FLOAT_SIZE];
+
+  // The excess-129 exponent spans roughly 2^-129 .. 2^126; beyond that the
+  // interpreter itself stores zero rather than a wrapped exponent.
+  ApplesoftVars::encodeFloat(1e300, out);
+  for (int i = 0; i < APPLESOFT_FLOAT_SIZE; i++) CHECK(out[i] == 0);
+
+  ApplesoftVars::encodeFloat(1e-300, out);
+  for (int i = 0; i < APPLESOFT_FLOAT_SIZE; i++) CHECK(out[i] == 0);
+}
+
+TEST_CASE("encodeFloat round-trips through decodeFloat", "[applesoft][float]") {
+  // 31 stored mantissa bits give about nine significant decimal digits.
+  const double values[] = {
+    1.0, -1.0, 0.5, -0.5, 2.0, 10.0, -10.0, 3.14159265, -2.718281828,
+    100.0, 0.001, 65535.0, -32768.0, 1.0 / 3.0, 1e10, 1e-10,
+  };
+
+  uint8_t out[APPLESOFT_FLOAT_SIZE];
+  for (double v : values) {
+    ApplesoftVars::encodeFloat(v, out);
+    CHECK(ApplesoftVars::decodeFloat(out) == Approx(v).epsilon(1e-9));
+  }
+}
+
+TEST_CASE("encodeFloat handles powers of two exactly", "[applesoft][float]") {
+  // log2() is not exact at powers of two, so this is where the normalisation
+  // nudge in encodeFloat earns its place.
+  uint8_t out[APPLESOFT_FLOAT_SIZE];
+  for (int e = -20; e <= 20; e++) {
+    const double v = std::pow(2.0, e);
+    ApplesoftVars::encodeFloat(v, out);
+    CHECK(ApplesoftVars::decodeFloat(out) == Approx(v));
+  }
+}
+
+// ============================================================================
+// Names and types
+// ============================================================================
+
+TEST_CASE("parseName decodes type from the name high bits", "[applesoft][name]") {
+  BasicVarType type;
+
+  // Neither high bit: real.
+  CHECK(nameOf('A', 'B', &type) == "AB");
+  CHECK(type == BasicVarType::Real);
+
+  // Second high bit only: string.
+  CHECK(nameOf('A', 'B' | 0x80, &type) == "AB$");
+  CHECK(type == BasicVarType::String);
+
+  // Both high bits: integer.
+  CHECK(nameOf('A' | 0x80, 'B' | 0x80, &type) == "AB%");
+  CHECK(type == BasicVarType::Integer);
+}
+
+TEST_CASE("parseName handles one-character names", "[applesoft][name]") {
+  BasicVarType type;
+
+  CHECK(nameOf('X', 0, &type) == "X");
+  CHECK(type == BasicVarType::Real);
+
+  // A one-character string: the suffix must still follow the single letter.
+  CHECK(nameOf('X', 0x80, &type) == "X$");
+  CHECK(type == BasicVarType::String);
+
+  CHECK(nameOf('X' | 0x80, 0x80, &type) == "X%");
+  CHECK(type == BasicVarType::Integer);
+}
+
+TEST_CASE("elementSize matches the in-array layout", "[applesoft][array]") {
+  CHECK(ApplesoftVars::elementSize(BasicVarType::Integer) == 2);
+  CHECK(ApplesoftVars::elementSize(BasicVarType::String) == 3);
+  CHECK(ApplesoftVars::elementSize(BasicVarType::Real) == APPLESOFT_FLOAT_SIZE);
+}
+
+// ============================================================================
+// Integers
+// ============================================================================
+
+TEST_CASE("decodeInteger is big-endian and signed", "[applesoft][integer]") {
+  CHECK(ApplesoftVars::decodeInteger(0x00, 0x00) == 0);
+  CHECK(ApplesoftVars::decodeInteger(0x00, 0x01) == 1);
+  CHECK(ApplesoftVars::decodeInteger(0x01, 0x00) == 256);
+  CHECK(ApplesoftVars::decodeInteger(0x7F, 0xFF) == 32767);
+
+  // Values at or above $8000 are negative.
+  CHECK(ApplesoftVars::decodeInteger(0xFF, 0xFF) == -1);
+  CHECK(ApplesoftVars::decodeInteger(0x80, 0x00) == -32768);
+}


### PR DESCRIPTION
First slice of Phase C. Self-contained and behaviour-preserving.

## What prompted the split

`condition_evaluator.cpp` already decoded Applesoft floats and walked VARTAB for named variables — specialised for breakpoint expressions (int32 results, single lookup). So Phase C is substantially **extraction from existing C++** rather than fresh porting from JS, and it splits naturally into primitives (this PR) and enumeration (next).

## The duplication

Applesoft's variable layout — the two-byte name whose high bits carry the type, the 5-byte MBF float, the big-endian integer, the length-plus-pointer string descriptor — was encoded in three places:

- `src/core/debug/condition_evaluator.cpp`
- `src/js/debug/basic-variable-inspector.js`
- and the float **encoder** existed *only* in JavaScript

`src/core/basic/applesoft_vars.{hpp,cpp}` is now the single home. The functions are pure — bytes in, values out, no `Emulator` or memory-reader dependency — so every caller can use them and they are directly testable.

`condition_evaluator.cpp` decodes through it now. Behaviour is unchanged: it still truncates toward zero for integer comparisons. The decoding simply no longer lives in two places that can drift.

## Tests

`test_applesoft_vars` — **104 assertions** over logic that previously had none:

- canonical encodings (`$81 00 00 00 00` = 1.0, `$84 20 00 00 00` = 10.0, `$80` = 0.5)
- the zero-exponent rule, asserted with a deliberately non-zero mantissa
- sign carried in bit 7 of the first mantissa byte
- encode/decode round-trips across positive, negative, fractional and extreme values
- exponent under/overflow clamping to Applesoft zero
- powers of two get their own case: `log2()` is inexact there, which is exactly what the normalisation nudge in `encodeFloat` exists to correct

The JS encoder shipped with no tests at all.

## Testing

- C++: 40/40 (adds `test_applesoft_vars`)
- JS: 61/61
- `npm run check` green — exports, core purity, token table, tests
- WASM builds clean

No JS changed in this PR, so there is no runtime-behaviour risk to the debugger UI.

## Next (C2)

The JS inspector still walks memory itself, and it is expensive: `_parseArray` issues one `_peekMemory` per byte of array data, so a 1,000-element real array costs 5,000 RPC round-trips through the Worker. Moving the VARTAB/ARYTAB walks into the core collapses that to a single call and reduces the 479-line inspector to display formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)