### PR TITLE
Phase C2: enumerate Applesoft variables through the core

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -321,6 +321,25 @@ if(EMSCRIPTEN)
                 \"_getSmartPortActivityWrite\", \
                 \"_clearSmartPortActivity\", \
                 \"_loadBasicProgram\", \
+                \"_refreshBasicVariables\", \
+                \"_getBasicVariableName\", \
+                \"_getBasicVariableType\", \
+                \"_getBasicVariableAddress\", \
+                \"_getBasicVariableReal\", \
+                \"_getBasicVariableInt\", \
+                \"_getBasicVariableString\", \
+                \"_refreshBasicArrays\", \
+                \"_getBasicArrayName\", \
+                \"_getBasicArrayType\", \
+                \"_getBasicArrayAddress\", \
+                \"_getBasicArrayNumDims\", \
+                \"_getBasicArrayDim\", \
+                \"_getBasicArrayElementCount\", \
+                \"_getBasicArrayReals\", \
+                \"_getBasicArrayInts\", \
+                \"_getBasicArrayStrings\", \
+                \"_getBasicArrayStringsSize\", \
+                \"_writeApplesoftFloat\", \
                 \"_generateStereoAudioSamples\", \
                 \"_setAudioVolume\", \
                 \"_setAudioMuted\", \

--- a/src/bindings/wasm_interface.cpp
+++ b/src/bindings/wasm_interface.cpp
@@ -13,6 +13,7 @@
 #include "../core/filesystem/prodos.hpp"
 #include "../core/filesystem/pascal.hpp"
 #include "../core/basic/basic_detokenizer.hpp"
+#include "../core/basic/applesoft_vars.hpp"
 #include "../core/basic/basic_tokenizer.hpp"
 #include "../core/debug/debug_log.hpp"
 #include "../core/input/keyboard.hpp"
@@ -2031,6 +2032,173 @@ EMSCRIPTEN_KEEPALIVE
 bool isNoSlotClockEnabled() {
   REQUIRE_EMULATOR_OR(false);
   return g_emulator->isNoSlotClockEnabled();
+}
+
+
+// ============================================================================
+// Applesoft variable inspection
+//
+// The debugger used to walk VARTAB/ARYTAB from JavaScript with one _peekMemory
+// per byte — a 1000-element real array cost 5000 round trips through the
+// Worker. The walk now happens here and the results are cached until the next
+// refresh call, so the UI pays one call for the metadata and one bulk heapRead
+// for each array's values.
+// ============================================================================
+
+static std::vector<a2e::BasicVariableInfo> g_basicVars;
+static std::vector<a2e::BasicArrayInfo> g_basicArrays;
+// Array strings are handed over as one NUL-separated blob per array; these keep
+// the blobs alive for as long as the pointers handed to JS are valid.
+static std::vector<std::string> g_basicArrayStringBlobs;
+
+static a2e::VarMemReadFn emulatorReader() {
+  return [](uint16_t addr) -> uint8_t { return g_emulator->peekMemory(addr); };
+}
+
+EMSCRIPTEN_KEEPALIVE
+int refreshBasicVariables() {
+  REQUIRE_EMULATOR_OR(0);
+  g_basicVars = a2e::ApplesoftVarReader::readVariables(emulatorReader());
+  return static_cast<int>(g_basicVars.size());
+}
+
+EMSCRIPTEN_KEEPALIVE
+const char* getBasicVariableName(int index) {
+  if (index < 0 || index >= (int)g_basicVars.size()) return "";
+  return g_basicVars[index].name.c_str();
+}
+
+EMSCRIPTEN_KEEPALIVE
+int getBasicVariableType(int index) {
+  if (index < 0 || index >= (int)g_basicVars.size()) return 0;
+  return static_cast<int>(g_basicVars[index].type);
+}
+
+EMSCRIPTEN_KEEPALIVE
+int getBasicVariableAddress(int index) {
+  if (index < 0 || index >= (int)g_basicVars.size()) return 0;
+  return g_basicVars[index].address;
+}
+
+EMSCRIPTEN_KEEPALIVE
+double getBasicVariableReal(int index) {
+  if (index < 0 || index >= (int)g_basicVars.size()) return 0.0;
+  return g_basicVars[index].realValue;
+}
+
+EMSCRIPTEN_KEEPALIVE
+int getBasicVariableInt(int index) {
+  if (index < 0 || index >= (int)g_basicVars.size()) return 0;
+  return g_basicVars[index].intValue;
+}
+
+EMSCRIPTEN_KEEPALIVE
+const char* getBasicVariableString(int index) {
+  if (index < 0 || index >= (int)g_basicVars.size()) return "";
+  return g_basicVars[index].stringValue.c_str();
+}
+
+EMSCRIPTEN_KEEPALIVE
+int refreshBasicArrays() {
+  REQUIRE_EMULATOR_OR(0);
+  g_basicArrays = a2e::ApplesoftVarReader::readArrays(emulatorReader());
+
+  // Flatten each array's strings into one NUL-separated blob so JS can fetch
+  // them with a single heapRead instead of a call per element.
+  g_basicArrayStringBlobs.clear();
+  g_basicArrayStringBlobs.reserve(g_basicArrays.size());
+  for (const auto& arr : g_basicArrays) {
+    std::string blob;
+    for (const auto& s : arr.stringValues) {
+      blob.append(s);
+      blob.push_back('\0');
+    }
+    g_basicArrayStringBlobs.push_back(std::move(blob));
+  }
+
+  return static_cast<int>(g_basicArrays.size());
+}
+
+EMSCRIPTEN_KEEPALIVE
+const char* getBasicArrayName(int index) {
+  if (index < 0 || index >= (int)g_basicArrays.size()) return "";
+  return g_basicArrays[index].name.c_str();
+}
+
+EMSCRIPTEN_KEEPALIVE
+int getBasicArrayType(int index) {
+  if (index < 0 || index >= (int)g_basicArrays.size()) return 0;
+  return static_cast<int>(g_basicArrays[index].type);
+}
+
+EMSCRIPTEN_KEEPALIVE
+int getBasicArrayAddress(int index) {
+  if (index < 0 || index >= (int)g_basicArrays.size()) return 0;
+  return g_basicArrays[index].address;
+}
+
+EMSCRIPTEN_KEEPALIVE
+int getBasicArrayNumDims(int index) {
+  if (index < 0 || index >= (int)g_basicArrays.size()) return 0;
+  return g_basicArrays[index].numDims;
+}
+
+EMSCRIPTEN_KEEPALIVE
+int getBasicArrayDim(int index, int dim) {
+  if (index < 0 || index >= (int)g_basicArrays.size()) return 0;
+  const auto& dims = g_basicArrays[index].dimensions;
+  if (dim < 0 || dim >= (int)dims.size()) return 0;
+  return dims[dim];
+}
+
+EMSCRIPTEN_KEEPALIVE
+int getBasicArrayElementCount(int index) {
+  if (index < 0 || index >= (int)g_basicArrays.size()) return 0;
+  return static_cast<int>(g_basicArrays[index].elementCount);
+}
+
+// Bulk value access: JS reads elementCount doubles / int32s straight out of the
+// heap. Null when the array is of another type or the index is out of range.
+EMSCRIPTEN_KEEPALIVE
+const double* getBasicArrayReals(int index) {
+  if (index < 0 || index >= (int)g_basicArrays.size()) return nullptr;
+  const auto& values = g_basicArrays[index].realValues;
+  return values.empty() ? nullptr : values.data();
+}
+
+EMSCRIPTEN_KEEPALIVE
+const int32_t* getBasicArrayInts(int index) {
+  if (index < 0 || index >= (int)g_basicArrays.size()) return nullptr;
+  const auto& values = g_basicArrays[index].intValues;
+  return values.empty() ? nullptr : values.data();
+}
+
+// NUL-separated string blob plus its byte length, so JS can split it after one
+// heapRead. Element count still comes from getBasicArrayElementCount.
+EMSCRIPTEN_KEEPALIVE
+const char* getBasicArrayStrings(int index) {
+  if (index < 0 || index >= (int)g_basicArrayStringBlobs.size()) return nullptr;
+  return g_basicArrayStringBlobs[index].data();
+}
+
+EMSCRIPTEN_KEEPALIVE
+int getBasicArrayStringsSize(int index) {
+  if (index < 0 || index >= (int)g_basicArrayStringBlobs.size()) return 0;
+  return static_cast<int>(g_basicArrayStringBlobs[index].size());
+}
+
+
+// Encode a double into Applesoft's 5-byte float and write it at `addr`. The
+// debugger's variable editor used to carry its own encoder; this keeps the one
+// in ApplesoftVars as the only implementation.
+EMSCRIPTEN_KEEPALIVE
+void writeApplesoftFloat(int addr, double value) {
+  REQUIRE_EMULATOR();
+  uint8_t bytes[a2e::APPLESOFT_FLOAT_SIZE];
+  a2e::ApplesoftVars::encodeFloat(value, bytes);
+  for (int i = 0; i < a2e::APPLESOFT_FLOAT_SIZE; i++) {
+    g_emulator->writeMemory(static_cast<uint16_t>(addr + i), bytes[i]);
+  }
 }
 
 } // extern "C"

--- a/src/core/basic/applesoft_vars.cpp
+++ b/src/core/basic/applesoft_vars.cpp
@@ -117,4 +117,173 @@ int32_t ApplesoftVars::decodeInteger(uint8_t high, uint8_t low) {
   return value;
 }
 
+
+// ============================================================================
+// Table walking
+// ============================================================================
+
+namespace {
+
+/** Read a little-endian zero-page pointer pair. */
+uint16_t readPointer(const VarMemReadFn &read, uint16_t zpAddr) {
+  return static_cast<uint16_t>(read(zpAddr) | (read(zpAddr + 1) << 8));
+}
+
+// Applesoft zero page: VARTAB/ARYTAB/STREND delimit the variable and array
+// regions. TXTTAB is $0801, and the tables always sit above it.
+constexpr uint16_t ZP_VARTAB = 0x69;
+constexpr uint16_t ZP_ARYTAB = 0x6B;
+constexpr uint16_t ZP_STREND = 0x6D;
+
+constexpr uint16_t MIN_TABLE_ADDR = 0x0800;
+constexpr uint16_t MAX_TABLE_ADDR = 0xC000; // I/O space starts here
+
+/** Simple variables are a fixed seven bytes: 2 name + 5 value. */
+constexpr uint16_t SIMPLE_VAR_SIZE = 7;
+
+bool plausibleRange(uint16_t lo, uint16_t hi) {
+  return lo != 0 && hi != 0 && lo < hi && lo >= MIN_TABLE_ADDR && hi <= MAX_TABLE_ADDR;
+}
+
+} // namespace
+
+std::string ApplesoftVarReader::readString(const VarMemReadFn &read, uint16_t ptr,
+                                           uint8_t length) {
+  if (length == 0 || ptr == 0) return {};
+
+  std::string out;
+  out.reserve(length);
+  for (uint8_t i = 0; i < length; i++) {
+    // Applesoft stores text with the high bit set.
+    out.push_back(static_cast<char>(read(static_cast<uint16_t>(ptr + i)) & 0x7F));
+  }
+  return out;
+}
+
+std::vector<BasicVariableInfo> ApplesoftVarReader::readVariables(const VarMemReadFn &read) {
+  std::vector<BasicVariableInfo> variables;
+
+  const uint16_t vartab = readPointer(read, ZP_VARTAB);
+  const uint16_t arytab = readPointer(read, ZP_ARYTAB);
+  if (!plausibleRange(vartab, arytab)) return variables;
+
+  for (uint16_t addr = vartab; addr + SIMPLE_VAR_SIZE <= arytab; addr += SIMPLE_VAR_SIZE) {
+    const uint8_t b1 = read(addr);
+    const uint8_t b2 = read(static_cast<uint16_t>(addr + 1));
+
+    // A zero first name byte marks the end of the used portion of the table.
+    if (b1 == 0) break;
+
+    BasicVariableInfo info;
+    char name[APPLESOFT_NAME_MAX];
+    ApplesoftVars::parseName(b1, b2, name, &info.type);
+    info.name = name;
+    info.address = addr;
+
+    const uint16_t value = static_cast<uint16_t>(addr + 2);
+    switch (info.type) {
+    case BasicVarType::Integer:
+      info.intValue = ApplesoftVars::decodeInteger(read(value),
+                                                   read(static_cast<uint16_t>(value + 1)));
+      break;
+    case BasicVarType::String: {
+      const uint8_t len = read(value);
+      const uint16_t ptr = static_cast<uint16_t>(read(static_cast<uint16_t>(value + 1)) |
+                                                 (read(static_cast<uint16_t>(value + 2)) << 8));
+      info.stringValue = readString(read, ptr, len);
+      break;
+    }
+    case BasicVarType::Real: {
+      uint8_t bytes[APPLESOFT_FLOAT_SIZE];
+      for (int i = 0; i < APPLESOFT_FLOAT_SIZE; i++) {
+        bytes[i] = read(static_cast<uint16_t>(value + i));
+      }
+      info.realValue = ApplesoftVars::decodeFloat(bytes);
+      break;
+    }
+    }
+
+    variables.push_back(std::move(info));
+  }
+
+  return variables;
+}
+
+std::vector<BasicArrayInfo> ApplesoftVarReader::readArrays(const VarMemReadFn &read) {
+  std::vector<BasicArrayInfo> arrays;
+
+  const uint16_t arytab = readPointer(read, ZP_ARYTAB);
+  const uint16_t strend = readPointer(read, ZP_STREND);
+  if (!plausibleRange(arytab, strend)) return arrays;
+
+  uint16_t addr = arytab;
+  while (addr + 5 <= strend) {
+    const uint8_t b1 = read(addr);
+    const uint8_t b2 = read(static_cast<uint16_t>(addr + 1));
+    if (b1 == 0) break;
+
+    BasicArrayInfo info;
+    char name[APPLESOFT_NAME_MAX];
+    ApplesoftVars::parseName(b1, b2, name, &info.type);
+    info.name = name;
+    info.address = addr;
+
+    // Header: 2 name + 2 total size (little-endian) + 1 dimension count.
+    info.totalSize = static_cast<uint16_t>(read(static_cast<uint16_t>(addr + 2)) |
+                                           (read(static_cast<uint16_t>(addr + 3)) << 8));
+    info.numDims = read(static_cast<uint16_t>(addr + 4));
+
+    // A zero or nonsensical total size would not advance the walk, so stop
+    // rather than spin on a corrupt header.
+    if (info.totalSize < 5 || addr + info.totalSize > strend) break;
+
+    // Dimension sizes are big-endian, unlike the total size.
+    uint32_t elementCount = info.numDims > 0 ? 1u : 0u;
+    for (uint8_t d = 0; d < info.numDims; d++) {
+      const uint16_t off = static_cast<uint16_t>(addr + 5 + d * 2);
+      const uint16_t dim = static_cast<uint16_t>((read(off) << 8) |
+                                                 read(static_cast<uint16_t>(off + 1)));
+      info.dimensions.push_back(dim);
+      elementCount *= dim;
+    }
+
+    if (elementCount > MAX_ARRAY_ELEMENTS) elementCount = MAX_ARRAY_ELEMENTS;
+    info.elementCount = elementCount;
+
+    const uint16_t dataStart = static_cast<uint16_t>(addr + 5 + info.numDims * 2);
+    const int stride = ApplesoftVars::elementSize(info.type);
+
+    for (uint32_t i = 0; i < elementCount; i++) {
+      const uint16_t elem = static_cast<uint16_t>(dataStart + i * stride);
+
+      switch (info.type) {
+      case BasicVarType::Integer:
+        info.intValues.push_back(
+            ApplesoftVars::decodeInteger(read(elem), read(static_cast<uint16_t>(elem + 1))));
+        break;
+      case BasicVarType::String: {
+        const uint8_t len = read(elem);
+        const uint16_t ptr = static_cast<uint16_t>(read(static_cast<uint16_t>(elem + 1)) |
+                                                   (read(static_cast<uint16_t>(elem + 2)) << 8));
+        info.stringValues.push_back(readString(read, ptr, len));
+        break;
+      }
+      case BasicVarType::Real: {
+        uint8_t bytes[APPLESOFT_FLOAT_SIZE];
+        for (int b = 0; b < APPLESOFT_FLOAT_SIZE; b++) {
+          bytes[b] = read(static_cast<uint16_t>(elem + b));
+        }
+        info.realValues.push_back(ApplesoftVars::decodeFloat(bytes));
+        break;
+      }
+      }
+    }
+
+    addr = static_cast<uint16_t>(addr + info.totalSize);
+    arrays.push_back(std::move(info));
+  }
+
+  return arrays;
+}
+
 } // namespace a2e

--- a/src/core/basic/applesoft_vars.hpp
+++ b/src/core/basic/applesoft_vars.hpp
@@ -20,8 +20,14 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
+#include <string>
+#include <vector>
 
 namespace a2e {
+
+/** Reads one byte of emulated memory. Matches basic_tokenizer's convention. */
+using VarMemReadFn = std::function<uint8_t(uint16_t)>;
 
 /** Applesoft variable types, as encoded in the high bits of the name bytes. */
 enum class BasicVarType { Real, Integer, String };
@@ -68,6 +74,60 @@ public:
 
   /** Decode a 2-byte big-endian Applesoft integer as signed. */
   static int32_t decodeInteger(uint8_t high, uint8_t low);
+};
+
+/** One simple (non-array) variable, with its value already decoded. */
+struct BasicVariableInfo {
+  std::string name;
+  BasicVarType type = BasicVarType::Real;
+  uint16_t address = 0;
+  double realValue = 0.0;  // Real
+  int32_t intValue = 0;    // Integer
+  std::string stringValue; // String
+};
+
+/** One array variable, with every element decoded. */
+struct BasicArrayInfo {
+  std::string name;
+  BasicVarType type = BasicVarType::Real;
+  uint16_t address = 0;
+  uint16_t totalSize = 0;
+  uint8_t numDims = 0;
+  std::vector<uint16_t> dimensions;
+  uint32_t elementCount = 0;
+  // Only the vector matching `type` is populated.
+  std::vector<double> realValues;
+  std::vector<int32_t> intValues;
+  std::vector<std::string> stringValues;
+};
+
+/**
+ * Walks Applesoft's variable and array tables in emulated memory.
+ *
+ * Applesoft lays these out as two contiguous regions: simple variables from
+ * VARTAB ($69) to ARYTAB ($6B), each a fixed seven bytes, then arrays from
+ * ARYTAB to STREND ($6D), each self-describing via a total-size field.
+ *
+ * Reading them here rather than in the debugger UI keeps the format knowledge
+ * next to the interpreter it belongs to, and collapses what used to be one
+ * memory read per byte of array data into a single call.
+ */
+class ApplesoftVarReader {
+public:
+  /**
+   * Arrays can address far more elements than a debugger can usefully show, and
+   * a corrupt header can claim an absurd count, so enumeration stops here.
+   */
+  static constexpr uint32_t MAX_ARRAY_ELEMENTS = 10000;
+
+  /** Read all simple variables between VARTAB and ARYTAB. */
+  static std::vector<BasicVariableInfo> readVariables(const VarMemReadFn &read);
+
+  /** Read all arrays between ARYTAB and STREND, including element values. */
+  static std::vector<BasicArrayInfo> readArrays(const VarMemReadFn &read);
+
+  /** Read a string body, masking off the high bit Applesoft leaves set. */
+  static std::string readString(const VarMemReadFn &read, uint16_t ptr, uint8_t length);
 };
 
 } // namespace a2e

--- a/src/js/debug/basic-variable-inspector.js
+++ b/src/js/debug/basic-variable-inspector.js
@@ -20,7 +20,12 @@
  * - String (3 bytes): Length byte + 2-byte pointer to string data
  */
 
-import { peek, readWord } from "../utils/wasm-memory.js";
+
+// Mirrors a2e::BasicVarType.
+const VAR_TYPES = ["real", "integer", "string"];
+
+// Applesoft simple variables are a fixed 7 bytes: 2 name + 5 value.
+const SIMPLE_VAR_SIZE = 7;
 
 export class BasicVariableInspector {
   constructor(wasmModule) {
@@ -32,28 +37,35 @@ export class BasicVariableInspector {
    * @returns {Array<{name: string, type: string, value: any, rawValue: Uint8Array}>}
    */
   async getSimpleVariables() {
+    const wasm = this.wasmModule;
+
+    // One call walks VARTAB..ARYTAB in the core and caches the result; the
+    // per-variable reads below are metadata only. Previously this decoded the
+    // Applesoft layout in JS with a _peekMemory round trip per byte.
+    const count = await wasm._refreshBasicVariables();
+    if (count <= 0) return [];
+
     const variables = [];
+    for (let i = 0; i < count; i++) {
+      const [namePtr, type, addr] = await wasm.batch([
+        ["_getBasicVariableName", i],
+        ["_getBasicVariableType", i],
+        ["_getBasicVariableAddress", i],
+      ]);
 
-    const vartab = await readWord(this.wasmModule,0x69);
-    const arytab = await readWord(this.wasmModule,0x6b);
+      const name = await wasm.UTF8ToString(namePtr);
+      const typeName = VAR_TYPES[type] ?? "real";
 
-    // No variables if pointers are invalid or equal (empty variable area)
-    if (vartab === 0 || arytab === 0 || vartab >= arytab) {
-      return variables;
-    }
+      let value;
+      if (typeName === "integer") {
+        value = await wasm._getBasicVariableInt(i);
+      } else if (typeName === "string") {
+        value = await wasm.UTF8ToString(await wasm._getBasicVariableString(i));
+      } else {
+        value = await wasm._getBasicVariableReal(i);
+      }
 
-    // Sanity check - variable area should be in reasonable range
-    if (vartab < 0x800 || arytab > 0xC000) {
-      return variables;
-    }
-
-    let addr = vartab;
-    while (addr < arytab) {
-      const varInfo = await this._parseVariable(addr);
-      if (!varInfo) break;
-
-      variables.push(varInfo);
-      addr += varInfo.size;
+      variables.push({ name, type: typeName, value, addr, size: SIMPLE_VAR_SIZE });
     }
 
     return variables;
@@ -64,249 +76,89 @@ export class BasicVariableInspector {
    * @returns {Array<{name: string, type: string, dimensions: number[], values: any[]}>}
    */
   async getArrayVariables() {
+    const wasm = this.wasmModule;
+
+    const count = await wasm._refreshBasicArrays();
+    if (count <= 0) return [];
+
     const arrays = [];
+    for (let i = 0; i < count; i++) {
+      const [namePtr, type, addr, numDims, elementCount] = await wasm.batch([
+        ["_getBasicArrayName", i],
+        ["_getBasicArrayType", i],
+        ["_getBasicArrayAddress", i],
+        ["_getBasicArrayNumDims", i],
+        ["_getBasicArrayElementCount", i],
+      ]);
 
-    const arytab = await readWord(this.wasmModule,0x6b);
-    const strend = await readWord(this.wasmModule,0x6d);
+      const name = await wasm.UTF8ToString(namePtr);
+      const typeName = VAR_TYPES[type] ?? "real";
 
-    if (arytab === 0 || strend === 0 || arytab >= strend) {
-      return arrays;
-    }
+      const dimCalls = [];
+      for (let d = 0; d < numDims; d++) dimCalls.push(["_getBasicArrayDim", i, d]);
+      const dimensions = numDims > 0 ? await wasm.batch(dimCalls) : [];
 
-    let addr = arytab;
-    while (addr < strend) {
-      const arrayInfo = await this._parseArray(addr);
-      if (!arrayInfo) break;
+      const values = await this._readArrayValues(i, typeName, elementCount);
 
-      arrays.push(arrayInfo);
-      addr += arrayInfo.totalSize;
+      arrays.push({
+        name,
+        type: typeName,
+        dimensions,
+        values,
+        totalElements: elementCount,
+        addr,
+        numDims,
+      });
     }
 
     return arrays;
   }
 
   /**
-   * Parse a single variable at the given address
+   * Read one array's element values in bulk.
+   *
+   * Values live contiguously in the WASM heap, so each array costs a single
+   * heapRead regardless of how many elements it holds — the point of moving the
+   * walk into the core. Strings arrive as one NUL-separated blob.
    */
-  async _parseVariable(addr) {
-    const [byte1, byte2] = await this.wasmModule.batch([
-      ['_peekMemory', addr],
-      ['_peekMemory', addr + 1],
-    ]);
+  async _readArrayValues(index, type, elementCount) {
+    if (elementCount <= 0) return [];
+    const wasm = this.wasmModule;
 
-    if (byte1 === 0) return null;
+    if (type === "string") {
+      const [ptr, size] = await wasm.batch([
+        ["_getBasicArrayStrings", index],
+        ["_getBasicArrayStringsSize", index],
+      ]);
+      if (!ptr || size <= 0) return new Array(elementCount).fill("");
 
-    const { name, type } = this._parseVariableName(byte1, byte2);
-    let value;
-    let rawValue;
-    let size;
-
-    // Batch read the value bytes (up to 5 bytes starting at addr+2)
-    const valueCalls = [];
-    for (let i = 0; i < 5; i++) {
-      valueCalls.push(['_peekMemory', addr + 2 + i]);
+      const blob = await wasm.heapRead(ptr, size);
+      const values = [];
+      let start = 0;
+      for (let i = 0; i < size; i++) {
+        if (blob[i] === 0) {
+          values.push(String.fromCharCode(...blob.subarray(start, i)));
+          start = i + 1;
+        }
+      }
+      // Pad in case the blob ended early — the UI indexes by element.
+      while (values.length < elementCount) values.push("");
+      return values;
     }
-    const valueBytes = await this.wasmModule.batch(valueCalls);
 
     if (type === "integer") {
-      // Integer: 2 bytes (high, low)
-      const high = valueBytes[0];
-      const low = valueBytes[1];
-      value = (high << 8) | low;
-      // Convert to signed
-      if (value >= 0x8000) value -= 0x10000;
-      rawValue = new Uint8Array([high, low]);
-      size = 7; // 2 name + 5 value (padded to match real size)
-    } else if (type === "string") {
-      // String: length + 2-byte pointer
-      const len = valueBytes[0];
-      const ptrLow = valueBytes[1];
-      const ptrHigh = valueBytes[2];
-      const ptr = (ptrHigh << 8) | ptrLow;
-      value = await this._readString(ptr, len);
-      rawValue = new Uint8Array([len, ptrLow, ptrHigh]);
-      size = 7; // 2 name + 3 value + 2 padding
-    } else {
-      // Real: 5-byte Applesoft float
-      const floatBytes = new Uint8Array(valueBytes);
-      value = this._decodeApplesoftFloat(floatBytes);
-      rawValue = floatBytes;
-      size = 7; // 2 name + 5 value
+      const ptr = await wasm._getBasicArrayInts(index);
+      if (!ptr) return new Array(elementCount).fill(0);
+      const bytes = await wasm.heapRead(ptr, elementCount * 4);
+      const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+      return Array.from({ length: elementCount }, (_, i) => view.getInt32(i * 4, true));
     }
 
-    return { name, type, value, rawValue, size, addr };
-  }
-
-  /**
-   * Parse an array variable header
-   */
-  async _parseArray(addr) {
-    // Read header: 2 name bytes + 2 size bytes + 1 numDims byte = 5 bytes
-    const headerCalls = [];
-    for (let i = 0; i < 5; i++) {
-      headerCalls.push(['_peekMemory', addr + i]);
-    }
-    const header = await this.wasmModule.batch(headerCalls);
-    const byte1 = header[0];
-    const byte2 = header[1];
-
-    if (byte1 === 0) return null;
-
-    const { name, type } = this._parseVariableName(byte1, byte2);
-
-    // Total size of array entry (including header) - stored little-endian
-    const totalSize = (header[3] << 8) | header[2];
-
-    // Number of dimensions
-    const numDims = header[4];
-
-    // Read dimension sizes (2 bytes each, stored high-low)
-    const dimCalls = [];
-    for (let i = 0; i < numDims * 2; i++) {
-      dimCalls.push(['_peekMemory', addr + 5 + i]);
-    }
-    const dimBytes = numDims > 0 ? await this.wasmModule.batch(dimCalls) : [];
-
-    const dimensions = [];
-    for (let i = 0; i < numDims; i++) {
-      dimensions.push((dimBytes[i * 2] << 8) | dimBytes[i * 2 + 1]);
-    }
-
-    // Calculate total elements
-    let totalElements = 1;
-    for (const dim of dimensions) {
-      totalElements *= dim;
-    }
-
-    // Read all element data in one batch
-    const dataStart = addr + 5 + numDims * 2;
-    const elementSize = type === "integer" ? 2 : type === "string" ? 3 : 5;
-    const elemCount = Math.min(totalElements, 10000);
-    const totalDataBytes = elemCount * elementSize;
-
-    const dataCalls = [];
-    for (let i = 0; i < totalDataBytes; i++) {
-      dataCalls.push(['_peekMemory', dataStart + i]);
-    }
-    const dataBytes = totalDataBytes > 0 ? await this.wasmModule.batch(dataCalls) : [];
-
-    // Parse values from the batch-read data
-    const values = [];
-    for (let i = 0; i < elemCount; i++) {
-      const offset = i * elementSize;
-      let elemValue;
-      if (type === "integer") {
-        const high = dataBytes[offset];
-        const low = dataBytes[offset + 1];
-        elemValue = (high << 8) | low;
-        if (elemValue >= 0x8000) elemValue -= 0x10000;
-      } else if (type === "string") {
-        const len = dataBytes[offset];
-        const ptrLow = dataBytes[offset + 1];
-        const ptrHigh = dataBytes[offset + 2];
-        const ptr = (ptrHigh << 8) | ptrLow;
-        elemValue = await this._readString(ptr, len);
-      } else {
-        const floatBytes = new Uint8Array(5);
-        for (let j = 0; j < 5; j++) {
-          floatBytes[j] = dataBytes[offset + j];
-        }
-        elemValue = this._decodeApplesoftFloat(floatBytes);
-      }
-      values.push(elemValue);
-    }
-
-    return {
-      name,
-      type,
-      dimensions,
-      values,
-      totalSize,
-      totalElements,
-      addr,
-      numDims,
-    };
-  }
-
-  /**
-   * Parse variable name from two bytes
-   */
-  _parseVariableName(byte1, byte2) {
-    // Extract characters (mask off high bits for char value)
-    const char1 = String.fromCharCode(byte1 & 0x7f);
-    const char2Raw = byte2 & 0x7f;
-    const char2 = char2Raw ? String.fromCharCode(char2Raw) : "";
-
-    // Determine type from high bits
-    // Integer: both high bits set
-    // String: second byte high bit set (but not both)
-    const isInteger = (byte1 & 0x80) !== 0 && (byte2 & 0x80) !== 0;
-    const isString = !isInteger && (byte2 & 0x80) !== 0;
-
-    let type = "real";
-    let suffix = "";
-    if (isInteger) {
-      type = "integer";
-      suffix = "%";
-    } else if (isString) {
-      type = "string";
-      suffix = "$";
-    }
-
-    return {
-      name: char1 + char2 + suffix,
-      type,
-    };
-  }
-
-  /**
-   * Decode Applesoft floating point format
-   * Format: exponent (1 byte) + mantissa (4 bytes)
-   * Exponent: excess-128 (0 = zero value)
-   * Mantissa: normalized with implied leading 1, sign in bit 7 of first mantissa byte
-   */
-  _decodeApplesoftFloat(bytes) {
-    const exp = bytes[0];
-
-    // Zero check
-    if (exp === 0) return 0;
-
-    // Sign is in bit 7 of mantissa byte 1
-    const sign = bytes[1] & 0x80 ? -1 : 1;
-
-    // Build mantissa as a number between 1 and 2 (normalized 1.xxxxx form)
-    // The implied leading 1 is not stored, so we start with 1.0
-    // Then add the fractional bits from the mantissa bytes
-    let mantissa = 1.0;
-    mantissa += (bytes[1] & 0x7F) / 128.0;        // 7 bits: values 0.5, 0.25, 0.125, etc.
-    mantissa += bytes[2] / 32768.0;               // next 8 bits
-    mantissa += bytes[3] / 8388608.0;             // next 8 bits
-    mantissa += bytes[4] / 2147483648.0;          // last 8 bits
-
-    // Applesoft uses excess-129 notation (the implied 1 is at position 2^-1, not 2^0)
-    // So the actual exponent is exp - 129
-    const actualExp = exp - 129;
-    const value = sign * mantissa * Math.pow(2, actualExp);
-
-    return value;
-  }
-
-  /**
-   * Read a string from memory
-   */
-  async _readString(ptr, len) {
-    if (len === 0 || ptr === 0) return "";
-
-    const batchCalls = [];
-    for (let i = 0; i < len; i++) {
-      batchCalls.push(['_peekMemory', ptr + i]);
-    }
-    const chars = await this.wasmModule.batch(batchCalls);
-    let str = "";
-    for (let i = 0; i < len; i++) {
-      str += String.fromCharCode(chars[i] & 0x7f);
-    }
-    return str;
+    const ptr = await wasm._getBasicArrayReals(index);
+    if (!ptr) return new Array(elementCount).fill(0);
+    const bytes = await wasm.heapRead(ptr, elementCount * 8);
+    const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    return Array.from({ length: elementCount }, (_, i) => view.getFloat64(i * 8, true));
   }
 
   /**
@@ -350,10 +202,8 @@ export class BasicVariableInspector {
       // Real number
       const parsed = parseFloat(newValueStr);
       if (isNaN(parsed)) return false;
-      const bytes = this._encodeApplesoftFloat(parsed);
-      for (let i = 0; i < 5; i++) {
-        this.wasmModule._writeMemory(valueAddr + i, bytes[i]);
-      }
+      // Encoding lives in the core (a2e::ApplesoftVars::encodeFloat).
+      this.wasmModule._writeApplesoftFloat(valueAddr, parsed);
       return true;
     }
   }
@@ -399,59 +249,10 @@ export class BasicVariableInspector {
     } else {
       const parsed = parseFloat(newValueStr);
       if (isNaN(parsed)) return false;
-      const bytes = this._encodeApplesoftFloat(parsed);
-      for (let i = 0; i < 5; i++) {
-        this.wasmModule._writeMemory(elemAddr + i, bytes[i]);
-      }
+      // Encoding lives in the core (a2e::ApplesoftVars::encodeFloat).
+      this.wasmModule._writeApplesoftFloat(elemAddr, parsed);
       return true;
     }
-  }
-
-  /**
-   * Encode a JavaScript number into 5-byte Applesoft floating point format
-   */
-  _encodeApplesoftFloat(value) {
-    const bytes = new Uint8Array(5);
-    if (value === 0) return bytes; // all zeros = 0.0
-
-    const sign = value < 0 ? 1 : 0;
-    let abs = Math.abs(value);
-
-    // Find exponent: normalize so 1.0 <= mantissa < 2.0
-    let exp = Math.floor(Math.log2(abs));
-    let mantissa = abs / Math.pow(2, exp);
-
-    // Adjust if mantissa is out of range due to floating point
-    if (mantissa < 1.0) { mantissa *= 2; exp--; }
-    if (mantissa >= 2.0) { mantissa /= 2; exp++; }
-
-    // Applesoft exponent is excess-129
-    const expByte = exp + 129;
-    if (expByte <= 0 || expByte > 255) return bytes; // underflow/overflow -> 0
-
-    bytes[0] = expByte;
-
-    // Remove the implicit leading 1
-    mantissa -= 1.0;
-
-    // Encode 31 bits of fractional mantissa across bytes[1..4]
-    // byte[1] has 7 fraction bits + sign in bit 7
-    mantissa *= 128; // 2^7
-    bytes[1] = (Math.floor(mantissa) & 0x7f) | (sign << 7);
-    mantissa -= Math.floor(mantissa);
-
-    mantissa *= 256;
-    bytes[2] = Math.floor(mantissa) & 0xff;
-    mantissa -= Math.floor(mantissa);
-
-    mantissa *= 256;
-    bytes[3] = Math.floor(mantissa) & 0xff;
-    mantissa -= Math.floor(mantissa);
-
-    mantissa *= 256;
-    bytes[4] = Math.round(mantissa) & 0xff;
-
-    return bytes;
   }
 
   /**

--- a/tests/unit/test_applesoft_vars.cpp
+++ b/tests/unit/test_applesoft_vars.cpp
@@ -13,6 +13,7 @@
 #include <cmath>
 #include <cstring>
 #include <string>
+#include <vector>
 
 using namespace a2e;
 
@@ -177,4 +178,166 @@ TEST_CASE("decodeInteger is big-endian and signed", "[applesoft][integer]") {
   // Values at or above $8000 are negative.
   CHECK(ApplesoftVars::decodeInteger(0xFF, 0xFF) == -1);
   CHECK(ApplesoftVars::decodeInteger(0x80, 0x00) == -32768);
+}
+
+// ============================================================================
+// Table walking
+// ============================================================================
+
+namespace {
+
+/** A 64K memory image that tests can lay Applesoft tables into by hand. */
+struct FakeMemory {
+  std::vector<uint8_t> ram = std::vector<uint8_t>(0x10000, 0);
+
+  VarMemReadFn reader() {
+    return [this](uint16_t addr) { return ram[addr]; };
+  }
+
+  void writePointer(uint16_t zp, uint16_t value) {
+    ram[zp] = value & 0xFF;
+    ram[zp + 1] = (value >> 8) & 0xFF;
+  }
+
+  /** Lay down a simple variable entry: 2 name bytes + 5 value bytes. */
+  void putVar(uint16_t addr, uint8_t b1, uint8_t b2, std::initializer_list<uint8_t> value) {
+    ram[addr] = b1;
+    ram[addr + 1] = b2;
+    int i = 0;
+    for (uint8_t v : value) ram[addr + 2 + i++] = v;
+  }
+
+  /** Applesoft stores string bodies with the high bit set. */
+  void putString(uint16_t addr, const std::string &text) {
+    for (size_t i = 0; i < text.size(); i++) {
+      ram[addr + i] = static_cast<uint8_t>(text[i]) | 0x80;
+    }
+  }
+};
+
+constexpr uint16_t VARTAB = 0x0900;
+
+} // namespace
+
+TEST_CASE("readVariables decodes each variable type", "[applesoft][reader]") {
+  FakeMemory mem;
+
+  // Three 7-byte entries: a real, an integer and a string.
+  mem.putVar(VARTAB + 0, 'A', 'B', {0x84, 0x20, 0x00, 0x00, 0x00}); // AB = 10.0
+  mem.putVar(VARTAB + 7, 'C' | 0x80, 'D' | 0x80, {0xFF, 0xFF, 0, 0, 0}); // CD% = -1
+  mem.putVar(VARTAB + 14, 'E', 'F' | 0x80, {5, 0x00, 0x0A, 0, 0}); // EF$ -> $0A00, len 5
+  mem.putString(0x0A00, "HELLO");
+
+  mem.writePointer(0x69, VARTAB);
+  mem.writePointer(0x6B, VARTAB + 21); // ARYTAB
+  mem.writePointer(0x6D, VARTAB + 21); // STREND
+
+  const auto vars = ApplesoftVarReader::readVariables(mem.reader());
+
+  REQUIRE(vars.size() == 3);
+
+  CHECK(vars[0].name == "AB");
+  CHECK(vars[0].type == BasicVarType::Real);
+  CHECK(vars[0].realValue == Approx(10.0));
+  CHECK(vars[0].address == VARTAB);
+
+  CHECK(vars[1].name == "CD%");
+  CHECK(vars[1].type == BasicVarType::Integer);
+  CHECK(vars[1].intValue == -1);
+
+  CHECK(vars[2].name == "EF$");
+  CHECK(vars[2].type == BasicVarType::String);
+  CHECK(vars[2].stringValue == "HELLO");
+}
+
+TEST_CASE("readVariables stops at an empty slot", "[applesoft][reader]") {
+  FakeMemory mem;
+  mem.putVar(VARTAB, 'A', 'B', {0x81, 0, 0, 0, 0});
+  // Next entry left as zeros: a zero name byte ends the table.
+
+  mem.writePointer(0x69, VARTAB);
+  mem.writePointer(0x6B, VARTAB + 70);
+  mem.writePointer(0x6D, VARTAB + 70);
+
+  CHECK(ApplesoftVarReader::readVariables(mem.reader()).size() == 1);
+}
+
+TEST_CASE("readVariables rejects implausible pointers", "[applesoft][reader]") {
+  FakeMemory mem;
+
+  auto empty = [&] { return ApplesoftVarReader::readVariables(mem.reader()).empty(); };
+
+  mem.writePointer(0x69, 0);      mem.writePointer(0x6B, 0x1000); CHECK(empty());
+  mem.writePointer(0x69, 0x1000); mem.writePointer(0x6B, 0x1000); CHECK(empty()); // equal
+  mem.writePointer(0x69, 0x2000); mem.writePointer(0x6B, 0x1000); CHECK(empty()); // inverted
+  mem.writePointer(0x69, 0x0100); mem.writePointer(0x6B, 0x1000); CHECK(empty()); // below TXTTAB
+  mem.writePointer(0x69, 0x1000); mem.writePointer(0x6B, 0xD000); CHECK(empty()); // into I/O
+}
+
+TEST_CASE("readArrays decodes dimensions and elements", "[applesoft][reader][array]") {
+  FakeMemory mem;
+
+  // A(3): header 2 name + 2 total size + 1 numDims + 2 per dimension, then
+  // three 5-byte reals holding 1.0, 2.0 and 10.0.
+  const uint16_t base = 0x0900;
+  const uint16_t total = 5 + 2 + 3 * 5; // 22
+  mem.ram[base] = 'A';
+  mem.ram[base + 1] = 0;
+  mem.ram[base + 2] = total & 0xFF;      // total size is little-endian
+  mem.ram[base + 3] = (total >> 8) & 0xFF;
+  mem.ram[base + 4] = 1;                 // one dimension
+  mem.ram[base + 5] = 0;                 // dimension size is BIG-endian
+  mem.ram[base + 6] = 3;
+
+  const uint16_t data = base + 7;
+  const uint8_t one[] = {0x81, 0x00, 0x00, 0x00, 0x00};
+  const uint8_t two[] = {0x82, 0x00, 0x00, 0x00, 0x00};
+  const uint8_t ten[] = {0x84, 0x20, 0x00, 0x00, 0x00};
+  for (int i = 0; i < 5; i++) {
+    mem.ram[data + i] = one[i];
+    mem.ram[data + 5 + i] = two[i];
+    mem.ram[data + 10 + i] = ten[i];
+  }
+
+  mem.writePointer(0x6B, base);          // ARYTAB
+  mem.writePointer(0x6D, base + total);  // STREND
+
+  const auto arrays = ApplesoftVarReader::readArrays(mem.reader());
+
+  REQUIRE(arrays.size() == 1);
+  CHECK(arrays[0].name == "A");
+  CHECK(arrays[0].type == BasicVarType::Real);
+  CHECK(arrays[0].numDims == 1);
+  CHECK(arrays[0].dimensions == std::vector<uint16_t>{3});
+  CHECK(arrays[0].elementCount == 3);
+  REQUIRE(arrays[0].realValues.size() == 3);
+  CHECK(arrays[0].realValues[0] == Approx(1.0));
+  CHECK(arrays[0].realValues[1] == Approx(2.0));
+  CHECK(arrays[0].realValues[2] == Approx(10.0));
+}
+
+TEST_CASE("readArrays does not spin on a corrupt total size", "[applesoft][reader][array]") {
+  FakeMemory mem;
+  const uint16_t base = 0x0900;
+
+  mem.ram[base] = 'A';
+  mem.ram[base + 1] = 0;
+  mem.ram[base + 2] = 0; // total size 0 would never advance the walk
+  mem.ram[base + 3] = 0;
+  mem.ram[base + 4] = 1;
+
+  mem.writePointer(0x6B, base);
+  mem.writePointer(0x6D, base + 100);
+
+  // Must terminate rather than loop forever.
+  CHECK(ApplesoftVarReader::readArrays(mem.reader()).empty());
+}
+
+TEST_CASE("readString masks the Applesoft high bit", "[applesoft][reader][string]") {
+  FakeMemory mem;
+  mem.putString(0x0A00, "HI!");
+
+  CHECK(ApplesoftVarReader::readString(mem.reader(), 0x0A00, 3) == "HI!");
+  CHECK(ApplesoftVarReader::readString(mem.reader(), 0x0A00, 0).empty());
+  CHECK(ApplesoftVarReader::readString(mem.reader(), 0, 5).empty());
 }


### PR DESCRIPTION
Replaces #28, which GitHub auto-closed when its base branch (`phase-c-basic-model`, from #27) was deleted on merge. Same branch and same commit, retargeted at `master` now that #27 has landed.

## The problem

The debugger's variable inspector walked VARTAB and ARYTAB itself, decoding Applesoft's layout in JavaScript with one `_peekMemory` call **per byte**. A 1000-element real array cost 5000 RPC round trips through the Worker to populate one panel.

## What changed

`ApplesoftVarReader` does the walk in the core, on top of the primitives from #27. The inspector drops **479 → 280 lines** and no longer knows the memory format at all.

Array values come back **in bulk** rather than through per-element accessors, which would have kept the round-trip problem in a new shape:

- reals and integers are read straight out of the heap as contiguous `double`/`int32` runs
- strings arrive as one NUL-separated blob

Each array now costs a single `heapRead` regardless of element count.

## Last of the float codec

`_encodeApplesoftFloat` duplicated `ApplesoftVars::encodeFloat` added in #27, so both write paths now call `_writeApplesoftFloat`. No JS copy of the codec remains.

In-place string editing deliberately stays in JS: it writes within the original allocation rather than allocating in Applesoft's string space. That is a UI constraint, not format knowledge.

## The Phase A check earning its keep

19 new exports. `check-exports.sh` caught **all of them** missing from `EXPORTED_FUNCTIONS` before the link — precisely the failure mode it was written for (silent dead-stripping, then a runtime error).

## Tests

Reader tests build a synthetic 64K memory image and cover:

- each variable type, including one- and two-character names
- end-of-table detection on a zero name byte
- rejection of implausible pointers (zero, equal, inverted, below TXTTAB, into I/O space)
- array dimensions, which are **big-endian** — unlike the little-endian total size sitting beside them in the same header
- termination on a corrupt zero total size, which would otherwise never advance the walk

`test_applesoft_vars` is now 135 assertions, up from 104.

## Testing

- C++: 40/40
- JS: 61/61
- `npm run check` green; WASM and vite builds clean

**Not exercised in a browser:** the variable panel's read and edit paths. This is the most behaviour-visible change of the Phase C work.

## Note

Dropped `rawValue` and `totalSize` from the returned records; neither had any consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)