### PR TITLE
Phase C3: share the core's statement scan with the debugger

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,6 +140,8 @@ if(EMSCRIPTEN)
                 \"_stepBasicStatement\", \
                 \"_getBasicTxtptr\", \
                 \"_getBasicStatementIndex\", \
+                \"_getBasicStatementCountForLine\", \
+                \"_getBasicStatementIndexForLine\", \
                 \"_setBasicHeatMapEnabled\", \
                 \"_clearBasicHeatMap\", \
                 \"_getBasicHeatMapSize\", \

--- a/src/bindings/wasm_interface.cpp
+++ b/src/bindings/wasm_interface.cpp
@@ -2201,4 +2201,22 @@ void writeApplesoftFloat(int addr, double value) {
   }
 }
 
+
+// Statement geometry for a given line, used by the BASIC debugger window. The
+// JS parser used to walk the tokens itself; sharing the core's scan means the
+// highlighted statement and the statement a breakpoint fires on cannot
+// disagree.
+EMSCRIPTEN_KEEPALIVE
+int getBasicStatementCountForLine(int lineNumber) {
+  REQUIRE_EMULATOR_OR(1);
+  return g_emulator->getBasicStatementCountForLine(static_cast<uint16_t>(lineNumber));
+}
+
+EMSCRIPTEN_KEEPALIVE
+int getBasicStatementIndexForLine(int lineNumber, int txtptr) {
+  REQUIRE_EMULATOR_OR(0);
+  return g_emulator->getBasicStatementIndexForLine(static_cast<uint16_t>(lineNumber),
+                                                   static_cast<uint16_t>(txtptr));
+}
+
 } // extern "C"

--- a/src/core/emulator.hpp
+++ b/src/core/emulator.hpp
@@ -123,6 +123,12 @@ public:
   uint16_t getBasicTxtptr() const;  // Get current TXTPTR for statement highlighting
   int getBasicStatementIndex();     // Get current statement index (0-based)
 
+  // Statement geometry for an arbitrary line, for the debugger UI. These use
+  // the same colon scan that drives statement breakpoint matching, so what the
+  // UI highlights and where execution actually breaks cannot disagree.
+  int getBasicStatementCountForLine(uint16_t lineNumber);
+  int getBasicStatementIndexForLine(uint16_t lineNumber, uint16_t txtptr);
+
   // BASIC line heat map
   void setBasicHeatMapEnabled(bool enabled) { basicHeatMapEnabled_ = enabled; }
   bool isBasicHeatMapEnabled() const { return basicHeatMapEnabled_; }

--- a/src/core/emulator/emulator_debug.cpp
+++ b/src/core/emulator/emulator_debug.cpp
@@ -223,6 +223,26 @@ int Emulator::getBasicStatementIndex() {
   return countColonsBetween(lineStart, txtptr);
 }
 
+int Emulator::getBasicStatementCountForLine(uint16_t lineNumber) {
+  const uint16_t lineStart = findCurrentLineStart(lineNumber);
+
+  // An unknown line still has one statement as far as the UI is concerned.
+  if (lineStart == 0) return 1;
+
+  // countColonsBetween stops at the line's NUL terminator, so an end address
+  // beyond any possible line body scans exactly one whole line.
+  return countColonsBetween(lineStart, 0xBFFF) + 1;
+}
+
+int Emulator::getBasicStatementIndexForLine(uint16_t lineNumber, uint16_t txtptr) {
+  const uint16_t lineStart = findCurrentLineStart(lineNumber);
+
+  // Before the line's text begins, execution is still on its first statement.
+  if (lineStart == 0 || txtptr < lineStart) return 0;
+
+  return countColonsBetween(lineStart, txtptr);
+}
+
 int Emulator::countColonsBetween(uint16_t lineStart, uint16_t txtptr) {
   // If TXTPTR is at or before line start, we're at statement 0
   if (lineStart == 0 || txtptr <= lineStart) return 0;

--- a/src/js/debug/basic-program-parser.js
+++ b/src/js/debug/basic-program-parser.js
@@ -16,7 +16,6 @@
  * - TXTPTR ($7A-$7B): Pointer to current position in program text
  */
 
-import { APPLESOFT_TOKENS } from "../utils/basic-tokens.js";
 import { indexBasicListing } from "../utils/basic-listing.js";
 
 export class BasicProgramParser {
@@ -275,147 +274,53 @@ export class BasicProgramParser {
 
   /**
    * Get current statement info for the given line and TXTPTR.
-   * Uses the cached program buffer from the last getLines() call for fast local access.
-   * Returns {statementIndex, statementCount, statementStart, statementEnd}
-   * where statementStart/End are character offsets in the detokenized text
+   *
+   * Returns {statementIndex, statementCount}, or null when TXTPTR is not
+   * within this line. The former statementStart/statementEnd character offsets
+   * are gone — they were computed on every call and read by nothing.
+   *
+   * @param {number} lineNumber
+   * @param {number} txtptr
+   * @returns {Promise<{statementIndex: number, statementCount: number}|null>}
    */
   async getCurrentStatementInfo(lineNumber, txtptr) {
     const line = await this.findLine(lineNumber);
     if (!line) return null;
 
-    // Use cached program bytes if available, otherwise load them
+    // Cached program bytes are needed for the containment check below.
     if (!this._programBytes) {
       const { txttab, vartab } = await this._readPointers();
       if (txttab === 0 || vartab === 0 || txttab >= vartab) return null;
       await this._loadProgramBytes(txttab, vartab);
     }
 
-    // Find end of this line's tokens from cached buffer
     const nextPtr = this._readWordCached(line.address);
     const tokenStart = line.tokenAddress;
-    const tokenEnd = nextPtr - 1; // -1 for null terminator
+    const tokenEnd = nextPtr - 1; // -1 for the null terminator
 
-    // If TXTPTR is outside this line, return null
-    if (txtptr < tokenStart || txtptr > tokenEnd) {
-      return null;
-    }
+    // TXTPTR outside this line means execution is not on it.
+    if (txtptr < tokenStart || txtptr > tokenEnd) return null;
 
-    // Parse tokenized bytes to find statement boundaries (colons not in quotes/REM/DATA)
-    const statementBoundaries = [0]; // Start positions in detokenized text
-    let inQuote = false;
-    let inRem = false;
-    let inData = false;
-    let detokenizedPos = 0;
-    let currentStatementIndex = 0;
+    // The colon scan lives in the core, where it also decides which statement a
+    // breakpoint fires on. Doing it here as well meant the highlight and the
+    // breakpoint could disagree — and the two JS scans disagreed with each
+    // other, since only this one treated colons inside DATA specially.
+    const [statementIndex, statementCount] = await this.wasmModule.batch([
+      ["_getBasicStatementIndexForLine", lineNumber, txtptr],
+      ["_getBasicStatementCountForLine", lineNumber],
+    ]);
 
-    for (let addr = tokenStart; addr < tokenEnd; addr++) {
-      const byte = this._peekCached(addr);
-
-      // Track if we've passed TXTPTR
-      if (addr === txtptr) {
-        currentStatementIndex = statementBoundaries.length - 1;
-      }
-
-      // Handle quotes
-      if (byte === 0x22) { // Quote
-        inQuote = !inQuote;
-        detokenizedPos++;
-        continue;
-      }
-
-      // Inside quote or REM - just count characters
-      if (inQuote || inRem) {
-        detokenizedPos++;
-        continue;
-      }
-
-      // Token range: $80-$EA
-      if (byte >= 0x80 && byte <= 0xea) {
-        const token = this._getTokenString(byte);
-        if (token) {
-          detokenizedPos += token.length;
-          if (byte === 0xb2) inRem = true; // REM
-          if (byte === 0x83) inData = true; // DATA
-          continue;
-        }
-      }
-
-      // Colon outside quotes/REM marks statement boundary
-      if (byte === 0x3a && !inData) { // Colon
-        detokenizedPos++;
-        statementBoundaries.push(detokenizedPos);
-        continue;
-      }
-
-      // Inside DATA - colons end DATA mode
-      if (inData && byte === 0x3a) {
-        inData = false;
-      }
-
-      detokenizedPos++;
-    }
-
-    // Add end position
-    statementBoundaries.push(line.text.length);
-
-    // Handle case where TXTPTR is at or past the last checked position
-    if (txtptr >= tokenEnd) {
-      currentStatementIndex = statementBoundaries.length - 2;
-    }
-
-    return {
-      statementIndex: currentStatementIndex,
-      statementCount: statementBoundaries.length - 1,
-      statementStart: statementBoundaries[currentStatementIndex] || 0,
-      statementEnd: statementBoundaries[currentStatementIndex + 1] || line.text.length,
-    };
+    return { statementIndex, statementCount };
   }
 
   /**
-   * Get the number of statements in a given line (colons + 1, respecting quotes/REM/DATA)
+   * Get the number of statements in a given line (colons + 1, respecting
+   * quotes and REM)
    * @param {number} lineNumber
    * @returns {Promise<number>} statement count (1 if no colons)
    */
   async getStatementCount(lineNumber) {
-    const line = await this.findLine(lineNumber);
-    if (!line) return 1;
-
-    // Use cached program bytes if available, otherwise load them
-    if (!this._programBytes) {
-      const { txttab, vartab } = await this._readPointers();
-      if (txttab === 0 || vartab === 0 || txttab >= vartab) return 1;
-      await this._loadProgramBytes(txttab, vartab);
-    }
-
-    const nextPtr = this._readWordCached(line.address);
-    const tokenStart = line.tokenAddress;
-    const tokenEnd = nextPtr - 1;
-
-    let colonCount = 0;
-    let inQuote = false;
-    let inRem = false;
-
-    for (let addr = tokenStart; addr < tokenEnd; addr++) {
-      const byte = this._peekCached(addr);
-      if (byte === 0) break;
-      if (inRem) continue;
-      if (byte === 0x22) { inQuote = !inQuote; continue; }
-      if (inQuote) continue;
-      if (byte === 0xB2) { inRem = true; continue; }
-      if (byte === 0x3A) colonCount++;
-    }
-
-    return colonCount + 1;
-  }
-
-  /**
-   * Get token string for a token byte
-   */
-  _getTokenString(byte) {
-    if (byte >= 0x80 && byte <= 0xea) {
-      return APPLESOFT_TOKENS[byte - 0x80] || null;
-    }
-    return null;
+    return this.wasmModule._getBasicStatementCountForLine(lineNumber);
   }
 
 }

--- a/tests/integration/test_emulator_basic.cpp
+++ b/tests/integration/test_emulator_basic.cpp
@@ -10,6 +10,9 @@
 
 #include "emulator.hpp"
 
+#include <cstdint>
+#include <vector>
+
 using namespace a2e;
 
 // ---------------------------------------------------------------------------
@@ -88,4 +91,153 @@ TEST_CASE("Emulator isBasicErrorHit is initially false", "[emulator][basic][erro
     emu.init();
 
     REQUIRE_FALSE(emu.isBasicErrorHit());
+}
+
+// ---------------------------------------------------------------------------
+// Statement geometry
+//
+// These back the BASIC debugger's statement highlighting. The same colon scan
+// decides which statement a breakpoint fires on, so the two cannot disagree.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+/**
+ * Write one tokenized program line into memory and point TXTTAB at it.
+ * Layout per line: [next-ptr:2][line-num:2][tokens...][00], then [00][00].
+ * Returns the address of the line's tokenized text.
+ */
+uint16_t layOutSingleLine(Emulator& emu, uint16_t lineNumber,
+                          const std::vector<uint8_t>& tokens) {
+    constexpr uint16_t TXTTAB = 0x0801;
+
+    const uint16_t lineSize = static_cast<uint16_t>(2 + 2 + tokens.size() + 1);
+    const uint16_t nextAddr = static_cast<uint16_t>(TXTTAB + lineSize);
+
+    emu.writeMemory(TXTTAB, nextAddr & 0xFF);
+    emu.writeMemory(TXTTAB + 1, (nextAddr >> 8) & 0xFF);
+    emu.writeMemory(TXTTAB + 2, lineNumber & 0xFF);
+    emu.writeMemory(TXTTAB + 3, (lineNumber >> 8) & 0xFF);
+
+    for (size_t i = 0; i < tokens.size(); i++) {
+        emu.writeMemory(static_cast<uint16_t>(TXTTAB + 4 + i), tokens[i]);
+    }
+    emu.writeMemory(static_cast<uint16_t>(TXTTAB + 4 + tokens.size()), 0x00);
+
+    // End-of-program marker
+    emu.writeMemory(nextAddr, 0x00);
+    emu.writeMemory(nextAddr + 1, 0x00);
+
+    // TXTTAB pointer
+    emu.writeMemory(0x67, TXTTAB & 0xFF);
+    emu.writeMemory(0x68, (TXTTAB >> 8) & 0xFF);
+
+    return TXTTAB + 4;
+}
+
+constexpr uint8_t T_PRINT = 0xBA;
+constexpr uint8_t T_REM   = 0xB2;
+constexpr uint8_t T_DATA  = 0x83;
+constexpr uint8_t COLON   = 0x3A;
+constexpr uint8_t QUOTE   = 0x22;
+
+} // namespace
+
+TEST_CASE("getBasicStatementCountForLine counts colon-separated statements",
+          "[emulator][basic][statement]") {
+    Emulator emu;
+    emu.init();
+
+    // 10 PRINT : PRINT : PRINT  -> three statements
+    layOutSingleLine(emu, 10, {T_PRINT, COLON, T_PRINT, COLON, T_PRINT});
+
+    REQUIRE(emu.getBasicStatementCountForLine(10) == 3);
+}
+
+TEST_CASE("getBasicStatementCountForLine returns 1 for a single statement",
+          "[emulator][basic][statement]") {
+    Emulator emu;
+    emu.init();
+
+    layOutSingleLine(emu, 10, {T_PRINT});
+
+    REQUIRE(emu.getBasicStatementCountForLine(10) == 1);
+}
+
+TEST_CASE("getBasicStatementCountForLine ignores colons inside strings",
+          "[emulator][basic][statement]") {
+    Emulator emu;
+    emu.init();
+
+    // 10 PRINT "A:B" -> one statement; the colon is string content
+    layOutSingleLine(emu, 10, {T_PRINT, QUOTE, 'A', COLON, 'B', QUOTE});
+
+    REQUIRE(emu.getBasicStatementCountForLine(10) == 1);
+}
+
+TEST_CASE("getBasicStatementCountForLine ignores colons after REM",
+          "[emulator][basic][statement]") {
+    Emulator emu;
+    emu.init();
+
+    // 10 REM A:B -> one statement; everything after REM is comment text
+    layOutSingleLine(emu, 10, {T_REM, 'A', COLON, 'B'});
+
+    REQUIRE(emu.getBasicStatementCountForLine(10) == 1);
+}
+
+TEST_CASE("getBasicStatementCountForLine treats a colon after DATA as a separator",
+          "[emulator][basic][statement]") {
+    Emulator emu;
+    emu.init();
+
+    // 10 DATA 1 : PRINT -> two statements. A colon ends the DATA statement,
+    // which is what the breakpoint scan has always assumed.
+    layOutSingleLine(emu, 10, {T_DATA, '1', COLON, T_PRINT});
+
+    REQUIRE(emu.getBasicStatementCountForLine(10) == 2);
+}
+
+TEST_CASE("getBasicStatementCountForLine returns 1 for an unknown line",
+          "[emulator][basic][statement]") {
+    Emulator emu;
+    emu.init();
+
+    layOutSingleLine(emu, 10, {T_PRINT});
+
+    REQUIRE(emu.getBasicStatementCountForLine(999) == 1);
+}
+
+TEST_CASE("getBasicStatementIndexForLine advances past each colon",
+          "[emulator][basic][statement]") {
+    Emulator emu;
+    emu.init();
+
+    // 10 PRINT : PRINT : PRINT
+    const uint16_t text = layOutSingleLine(emu, 10, {T_PRINT, COLON, T_PRINT, COLON, T_PRINT});
+
+    CHECK(emu.getBasicStatementIndexForLine(10, text) == 0);           // at PRINT
+    CHECK(emu.getBasicStatementIndexForLine(10, text + 2) == 1);       // past first colon
+    CHECK(emu.getBasicStatementIndexForLine(10, text + 4) == 2);       // past second colon
+}
+
+TEST_CASE("getBasicStatementIndexForLine clamps before the line text",
+          "[emulator][basic][statement]") {
+    Emulator emu;
+    emu.init();
+
+    const uint16_t text = layOutSingleLine(emu, 10, {T_PRINT, COLON, T_PRINT});
+
+    // TXTPTR still on the line header counts as the first statement.
+    REQUIRE(emu.getBasicStatementIndexForLine(10, text - 2) == 0);
+}
+
+TEST_CASE("getBasicStatementIndexForLine returns 0 for an unknown line",
+          "[emulator][basic][statement]") {
+    Emulator emu;
+    emu.init();
+
+    layOutSingleLine(emu, 10, {T_PRINT, COLON, T_PRINT});
+
+    REQUIRE(emu.getBasicStatementIndexForLine(999, 0x0805) == 0);
 }


### PR DESCRIPTION
Final slice of Phase C. The BASIC debugger walked each line's tokens in JavaScript to work out statement boundaries — but the core already did the same scan, since that is what decides which statement a breakpoint fires on. Highlight and breakpoint were computed by two separate implementations.

## They disagreed

`getCurrentStatementInfo` treated a colon inside DATA as **not** a statement boundary. `getStatementCount`, sitting right beside it in the same class, ignored DATA entirely. So for:

```basic
10 DATA 1 : PRINT
```

the statement *count* and the statement *index* used different rules, and neither matched the core — which has always counted that colon as a separator.

Applesoft ends a DATA statement at a colon, so the core is correct. Sharing its scan makes all three agree, and means the highlighted statement is by construction the one a breakpoint fires on.

## What changed

- `Emulator::getBasicStatementCountForLine` and `getBasicStatementIndexForLine`, built on the existing `findCurrentLineStart` and `countColonsBetween`
- two exports
- the parser's own walk is gone, along with `_getTokenString` and the last use of `APPLESOFT_TOKENS` in the debugger

## Dead code removed

`statementStart` / `statementEnd` are gone from the returned object. They were character offsets into the detokenized text, recomputed on every call, and **read by nothing** — flagged as deletable when Phase B migrated the detokenizer, and this is where that lands.

`basic-program-parser.js` is now **321 lines**, down from 421 before Phase B.

## Tests

Integration tests cover both entry points:

- plain colon-separated statements
- colons inside string literals
- colons after REM
- the DATA case above, pinning the behaviour that used to differ three ways
- unknown line numbers
- TXTPTR still on the line header, before the text begins

## Testing

- C++: 40/40
- JS: 61/61
- `npm run check` green; WASM and vite builds clean

**Not exercised in a browser:** statement highlighting and statement breakpoints in the BASIC program window. The DATA change is user-visible for lines that contain one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)