### PR TITLE
Don't hold the paste speed boost across a pause

### DIFF
--- a/src/js/input/input-handler.js
+++ b/src/js/input/input-handler.js
@@ -5,6 +5,10 @@
  *  Mike Daley <michael_daley@icloud.com>
  */
 
+// How often to re-check a paste queue that is stalled because the emulator
+// is paused. Long enough not to busy-wait, short enough to feel immediate.
+const PAUSED_POLL_MS = 50;
+
 export class InputHandler {
   constructor(wasmModule) {
     this.wasmModule = wasmModule;
@@ -20,6 +24,7 @@ export class InputHandler {
     this.pasteQueue = [];
     this.pasteTimer = null;
     this.pasteSpeedUp = false; // whether we've set a speed multiplier for paste
+    this.pasteMultiplier = 1;  // boost the current queue asked for
     this.savedSpeedMultiplier = 1; // speed before paste started
 
     // MessageChannel for zero-delay batch scheduling (avoids setTimeout's ~4ms minimum)
@@ -203,6 +208,26 @@ export class InputHandler {
       return;
     }
 
+    // Nothing can drain while the emulator is paused: _runCycles is a no-op and
+    // the keyboard strobe never clears, so the loop below would spin its whole
+    // time budget and reschedule with the speed boost still applied. A
+    // breakpoint hit mid-queue therefore left the multiplier at 8x, and the
+    // emulator sprinted as soon as it was continued. Drop the boost while
+    // paused and check back periodically instead of spinning.
+    if (this.wasmModule._isPaused && (await this.wasmModule._isPaused())) {
+      this.restorePasteSpeed();
+      this.pasteTimer = setTimeout(() => {
+        this.pasteTimer = null;
+        this.processPasteQueue();
+      }, PAUSED_POLL_MS);
+      return;
+    }
+
+    // Re-apply the boost if a pause dropped it.
+    if (!this.pasteSpeedUp && this.pasteMultiplier > 1) {
+      await this.setPasteSpeed(this.pasteMultiplier);
+    }
+
     const BOOST_BATCH = 500; // small cycle batch for immediate key processing
     const TIME_BUDGET_MS = 30;
     const batchEnd = performance.now() + TIME_BUDGET_MS;
@@ -261,8 +286,10 @@ export class InputHandler {
 
   // Cancel any pending paste operation
   cancelPaste() {
+    if (typeof this.pasteTimer === "number") clearTimeout(this.pasteTimer);
     this.pasteTimer = null;
     this.pasteQueue = [];
+    this.pasteMultiplier = 1;
     this.restorePasteSpeed();
     if (this.pasteOnComplete) {
       this.pasteOnComplete(true); // true = cancelled
@@ -279,6 +306,7 @@ export class InputHandler {
   //   ordinary paste passes braces through literally.
   async queueTextInput(text, { speedMultiplier = 8, onStart = null, onComplete = null, parseTokens = false } = {}) {
     this.pasteOnComplete = onComplete;
+    this.pasteMultiplier = speedMultiplier;
     await this.setPasteSpeed(speedMultiplier);
 
     if (parseTokens) {


### PR DESCRIPTION
Addresses the report that continuing from a BASIC breakpoint leaves the emulator running fast.

## Diagnosis

Emulation only advances two ways:

1. **Audio sample requests** — the worklet requests a fixed 1600 frames when the ring buffer drops below 1600, with a `pendingRequest` guard allowing one in flight. That is self-limiting and cannot burst, so there is no frame backlog to catch up on. `Audio::generateStereoSamples` also clamps a cycle range wider than 2x expected.
2. **The paste queue's `_runCycles`.**

So the only thing that can make the emulator run *fast* is `speedMultiplier_`, and the paste queue is the only caller that sets it.

## The bug

Typing text into the emulator — paste, and the BASIC window's Run, which sends `"RUN\r"` — sets the multiplier to 8x and restores it when the queue drains.

The queue cannot drain while the emulator is paused: `_runCycles` is a no-op behind `if (paused_) return;`, and the keyboard strobe never clears, so `_isKeyboardReady()` never goes true. `processPasteQueue` therefore span its whole 30ms time budget, found the queue still non-empty, and rescheduled — **with the boost still applied**.

A breakpoint hit while a keystroke was still queued left the multiplier at 8x for as long as the emulator stayed paused, and it ran fast the moment it was continued.

## The fix

The drain loop now checks for a paused emulator before doing anything else: it drops the boost and polls every 50ms rather than spinning. The requested multiplier is remembered so the boost is re-applied once emulation resumes.

`cancelPaste` also clears a pending poll timer, which it previously leaked.

## Testing

- JS 61/61, `npm run check` green, vite build clean

**Not reproduced in a browser.** The diagnosis is by inspection and I am confident about the mechanism, but not that it is necessarily the same thing observed. A useful confirmation either way: with the current build, does the speed settle back to normal on its own after a second or two (queue eventually drains), or does it stay fast indefinitely? The former matches this cause; the latter would point elsewhere.

This is pre-existing behaviour — nothing in the recent Phase A–C work touches timing, pause, or input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)