### PR TITLE
Tidy up the joystick button mapping from #26

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ npm run deploy        # Deploy to VPS via rsync
 | Backspace | Delete (left arrow) |
 | Arrow Keys | Arrow Keys |
 | Left Alt | Open Apple (joystick button 0) |
-| Right Alt / Win | Closed Apple (joystick button 1) |
+| Right Alt | Closed Apple (joystick button 1) |
 | Ctrl+Letter | Control characters |
 | Escape | ESC |
 | Enter | Return |

--- a/src/js/help/documentation-window.js
+++ b/src/js/help/documentation-window.js
@@ -311,7 +311,7 @@ export class DocumentationWindow extends BaseWindow {
           </thead>
           <tbody>
             <tr><td><kbd>Alt</kbd> (Left)</td><td>Open Apple (&#63743;)</td><td>Modifier key, joystick button 0</td></tr>
-            <tr><td><kbd>Alt</kbd> (Right) / <kbd>Win</kbd></td><td>Closed Apple</td><td>Modifier key, joystick button 1</td></tr>
+            <tr><td><kbd>Alt</kbd> (Right)</td><td>Closed Apple</td><td>Modifier key, joystick button 1</td></tr>
             <tr><td><kbd>Ctrl</kbd></td><td>Control</td><td>Control key modifier</td></tr>
             <tr><td><kbd>Ctrl</kbd>+<kbd>Pause/Break</kbd></td><td>Reset</td><td>Warm reset (Ctrl+Reset)</td></tr>
           </tbody>

--- a/src/js/input/input-handler.js
+++ b/src/js/input/input-handler.js
@@ -9,6 +9,13 @@
 // is paused. Long enough not to busy-wait, short enough to feel immediate.
 const PAUSED_POLL_MS = 50;
 
+// Right Alt reports location 2; left reports 1, and 0 means the browser did not
+// say, which we treat as left. Both sides share keyCode 18, so this is the only
+// thing separating Open Apple from Closed Apple.
+export function isRightAlt(event) {
+  return event.location === 2;
+}
+
 export class InputHandler {
   constructor(wasmModule) {
     this.wasmModule = wasmModule;
@@ -123,23 +130,24 @@ export class InputHandler {
       return;
     }
 
-    // Joystick buttons: Left Alt → Button 0 (Open Apple), Right Alt → Button 1 (Closed Apple)
-    if (keyCode === 18 && !ctrl && !meta) {
-      const loc = event.location || 0;
-      if (loc === 1 || loc === 0) {
-        // Left Alt or unknown → Button 0
-        event.preventDefault();
-        this.wasmModule._setButton(0, true);
-        this.wasmModule._handleRawKeyDown(18, shift, ctrl, alt, meta, capsLock);
-        return;
-      }
-      if (loc === 2) {
-        // Right Alt → Button 1
-        event.preventDefault();
-        this.wasmModule._setButton(1, true);
-        this.wasmModule._handleRawKeyDown(91, shift, ctrl, alt, meta, capsLock);
-        return;
-      }
+    // Joystick buttons: Left Alt → Button 0 (Open Apple), Right Alt → Button 1
+    // (Closed Apple). keyCode is 18 for both sides and event.key is "Alt" for
+    // both on US layouts, so event.location is the only reliable discriminator.
+    //
+    // The core owns the button state: handleRawKeyDown maps 18 to Open Apple
+    // and 91 to Closed Apple, then copies both into buttonState_ itself
+    // (emulator.cpp), so no separate _setButton call is needed here.
+    if (keyCode === 18) {
+      // Alt on its own would otherwise focus the browser menu bar. Combinations
+      // are left alone: Ctrl+Alt is AltGr on European layouts, and swallowing it
+      // would interfere with typing accented characters.
+      if (!ctrl && !meta) event.preventDefault();
+
+      this.wasmModule._handleRawKeyDown(
+        isRightAlt(event) ? 91 : 18,
+        shift, ctrl, alt, meta, capsLock,
+      );
+      return;
     }
     // Win / Context Menu → block, do nothing
     if (keyCode === 91 || keyCode === 93) {
@@ -177,19 +185,13 @@ export class InputHandler {
     const alt = event.altKey;
     const meta = event.metaKey;
 
-    // Release joystick buttons
+    // Release joystick buttons — mirrors the keydown mapping above.
     if (keyCode === 18) {
-      const loc = event.location || 0;
-      if (loc === 1 || loc === 0) {
-        this.wasmModule._setButton(0, false);
-        this.wasmModule._handleRawKeyUp(18, shift, ctrl, alt, meta);
-        return;
-      }
-      if (loc === 2) {
-        this.wasmModule._setButton(1, false);
-        this.wasmModule._handleRawKeyUp(91, shift, ctrl, alt, meta);
-        return;
-      }
+      this.wasmModule._handleRawKeyUp(
+        isRightAlt(event) ? 91 : 18,
+        shift, ctrl, alt, meta,
+      );
+      return;
     }
     // Win / Context Menu → ignore release
     if (keyCode === 91 || keyCode === 93) {

--- a/tests/js/input/is-right-alt.test.js
+++ b/tests/js/input/is-right-alt.test.js
@@ -1,0 +1,37 @@
+/*
+ * is-right-alt.test.js - Which Alt key maps to which Apple button
+ *
+ * Written by
+ *  Mike Daley <michael_daley@icloud.com>
+ */
+
+import { describe, it, expect } from "vitest";
+import { isRightAlt } from "../../../src/js/input/input-handler.js";
+
+// KeyboardEvent.DOM_KEY_LOCATION_*
+const STANDARD = 0;
+const LEFT = 1;
+const RIGHT = 2;
+
+describe("isRightAlt", () => {
+  it("treats location 2 as the right Alt", () => {
+    expect(isRightAlt({ location: RIGHT })).toBe(true);
+  });
+
+  it("treats location 1 as the left Alt", () => {
+    expect(isRightAlt({ location: LEFT })).toBe(false);
+  });
+
+  it("treats an unspecified location as the left Alt", () => {
+    // Location 0 means the browser did not say which side. Falling back to
+    // left keeps Open Apple working rather than silently producing Closed
+    // Apple on a synthetic or unusual event.
+    expect(isRightAlt({ location: STANDARD })).toBe(false);
+    expect(isRightAlt({})).toBe(false);
+  });
+
+  it("does not treat a numeric-keypad location as right", () => {
+    // DOM_KEY_LOCATION_NUMPAD is 3; only 2 is the right-hand modifier.
+    expect(isRightAlt({ location: 3 })).toBe(false);
+  });
+});

--- a/wiki/Input-Devices.md
+++ b/wiki/Input-Devices.md
@@ -21,8 +21,8 @@ The emulator translates browser keycodes to Apple II ASCII codes in real time. A
 
 | Host Key | Apple II Function |
 |----------|-------------------|
-| Alt (Option) | Open Apple button |
-| Meta (Cmd/Win) | Closed Apple button |
+| Left Alt (Option) | Open Apple button |
+| Right Alt (Option) | Closed Apple button |
 | Shift | Shift (uppercase, shifted symbols) |
 | Ctrl | Control (generates control characters Ctrl+A through Ctrl+Z) |
 | Caps Lock | Uppercase letters (matches Apple II behavior) |

--- a/wiki/Keyboard-Shortcuts.md
+++ b/wiki/Keyboard-Shortcuts.md
@@ -37,7 +37,7 @@ The emulator translates modern keyboard input to Apple IIe key codes. Standard a
 | Your Keyboard | Apple //e Key | Notes |
 |---------------|---------------|-------|
 | Left Alt | Open Apple | Modifier key, joystick button 0 |
-| Right Alt / Windows key | Closed Apple (Solid Apple) | Modifier key, joystick button 1 |
+| Right Alt | Closed Apple (Solid Apple) | Modifier key, joystick button 1 |
 | Ctrl | Control | Control key modifier |
 | Shift | Shift | Shift modifier |
 | Caps Lock | Caps Lock | Tracked and sent to the emulator core |


### PR DESCRIPTION
Follow-ups from the review of #26, plus the doc updates promised there. Thanks again to @anomixer for the original fix — the Left/Right Alt split is unchanged, this just tidies the edges.

## Dropped the `_setButton()` calls

`handleRawKeyDown` / `handleRawKeyUp` already copy the keyboard's Open/Closed Apple flags into `buttonState_` (`emulator.cpp:576-577`), so the core reaches the same state on its own.

## Made the two handlers agree on which side is which

This turned out to be more than cosmetic. Keydown guarded the mapping with `!ctrl && !meta`; keyup did not. So releasing **Right Alt while Ctrl was held** fell through to the generic path, which calls `_handleRawKeyUp(18, ...)` — releasing button **0**, and leaving Closed Apple stuck down.

Both handlers now map the side unconditionally.

The guard is kept for `preventDefault` alone, which is what it was really protecting: Alt on its own would focus the browser menu bar, but Ctrl+Alt is AltGr on European layouts and swallowing it would interfere with typing accented characters.

## Made the decision testable

The left/right choice moves into an exported `isRightAlt()`, which is the extraction suggested in the review. Four tests cover it: location 2 is the right-hand key, location 1 is left, and an unspecified location (0, or absent) falls back to left — so an odd or synthetic event produces Open Apple rather than Closed. Numpad location 3 is also checked, since only 2 means right.

## Docs

`README.md`, `wiki/Input-Devices.md`, `wiki/Keyboard-Shortcuts.md` and the in-app help all still listed Win/Cmd as Closed Apple, which #26 stopped mapping. Updated to match.

Unrelated Cmd references (Cmd+V paste, Cmd+S save) are untouched.

## Testing

- JS 65/65 (adds 4)
- `npm run check` green; vite build clean

No C++ changed, so the Catch2 suites are unaffected.

## Still outstanding

The mapping still lives in JavaScript and works by sending keyCode 91 to mean "Closed Apple" — the core is told Meta is down when it isn't. Moving it into `Keyboard::handleKeyDown` with `event.location` passed through would put it in one place and stop a second front end having to reimplement it. That needs an ABI change and a WASM rebuild, so it is left as its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)