### PR TITLE
Release 1.1.6

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,11 +15,38 @@ npm run dev           # Start dev server at localhost:3000 (hot-reload for JS on
 npm run build         # Full production build (WASM + Vite bundle)
 npm run clean         # Clean build artifacts
 npm run deploy        # Deploy to VPS via rsync
+npm test              # JavaScript tests (Vitest)
+npm run check         # check:exports + check:core-purity + check:basic-tokens + npm test
+npm run generate:basic-tokens  # Regenerate src/js/utils/basic-tokens.js from C++
 ```
 
 ## Testing
 
-All tests use the Catch2 framework and are built/run via CMake's native build:
+### JavaScript (Vitest)
+
+`npm test` runs `tests/js/`. Config is in `vitest.config.js`, kept separate from
+`vite.config.js` so the app build settings do not obscure test failures. The
+modules under test are pure logic and run in plain node — a new DOM dependency
+in one of them is a smell, not a reason to add jsdom.
+
+Covers the printer emulation (characterization tests capturing the event stream
+from `PrinterBase.setEventSink()`), the Applesoft listing parser, and input
+mapping.
+
+### Consistency checks
+
+`npm run check` runs three guards, each verified to fail when violated:
+
+- `scripts/check-exports.sh` — `EMSCRIPTEN_KEEPALIVE` functions vs the
+  `EXPORTED_FUNCTIONS` list in `CMakeLists.txt`, both directions
+- `scripts/check-core-purity.sh` — no host-platform dependencies in `src/core/`
+  (matches code, not comments, so docs may name what they warn about)
+- `scripts/generate-basic-tokens.mjs --check` — the generated JS token table is
+  in step with `src/core/basic/basic_tokens.hpp`
+
+### C++ (Catch2)
+
+All C++ tests use the Catch2 framework and are built/run via CMake's native build:
 
 ```bash
 mkdir -p build-native && cd build-native
@@ -53,8 +80,10 @@ Test suites cover CPU (6502/65C02), memory (MMU, slots), video, audio, disk imag
 - `cards/ssc/` - Super Serial Card with ACIA 6551 (drives ImageWriter I and ImageWriter II)
 - `cards/thunderclock/` - Thunderclock Plus real-time clock card
 - `filesystem/` - DOS 3.3 and ProDOS filesystem parsers
-- `basic/` - Applesoft and Integer BASIC detokenizer and tokenizer
-- `debug/` - Condition evaluator for breakpoint expressions (supports BV/BA/BA2 for BASIC variable/array reads)
+- `basic/` - Applesoft and Integer BASIC detokenizer, tokenizer, token tables, and
+  variable representation (`applesoft_vars` — MBF floats, name/type decoding,
+  VARTAB/ARYTAB walking)
+- `debug/` - Condition evaluator for breakpoint expressions (supports BV/BA/BA2 for BASIC variable/array reads), and `debug_log` (host-installed log sink; the core never writes to a console itself)
 - `noslot_clock.cpp` - DS1215 No-Slot Clock (ProDOS RTC at $C300)
 - `emulator.cpp` - Core coordinator
 - `emulator/emulator_state.cpp` - State serialization (exportState/importState)
@@ -174,8 +203,8 @@ src/
 │   │   ├── ssc/           # Super Serial Card + ACIA 6551
 │   │   └── thunderclock/  # Thunderclock Plus real-time clock
 │   ├── filesystem/     # DOS 3.3 and ProDOS parsers
-│   ├── basic/          # BASIC tokenizer and detokenizer
-│   ├── debug/          # Condition evaluator
+│   ├── basic/          # BASIC tokenizer, detokenizer, Applesoft variable model
+│   ├── debug/          # Condition evaluator, host debug log sink
 │   ├── emulator/       # Split emulator implementation files
 │   │   ├── emulator_state.cpp  # State serialization (exportState/importState)
 │   │   └── emulator_debug.cpp  # Debug facilities (breakpoints, watchpoints, trace, beam)

--- a/README.md
+++ b/README.md
@@ -69,7 +69,21 @@ Open http://localhost:3000 in your browser.
 npm run build         # Full production build (WASM + Vite bundle)
 npm run clean         # Clean build artifacts
 npm run deploy        # Deploy to VPS via rsync
+npm test              # Run the JavaScript test suite (Vitest)
+npm run check         # Consistency checks + JavaScript tests
 ```
+
+`npm run check` runs three guards before the tests:
+
+- **`check:exports`** — every `EMSCRIPTEN_KEEPALIVE` function matches the
+  `EXPORTED_FUNCTIONS` list in `CMakeLists.txt`, in both directions. A missing
+  entry is dead-stripped by the linker and fails at runtime; a stale one is a
+  leftover.
+- **`check:core-purity`** — `src/core/` contains no host-platform dependencies.
+  Platform glue belongs in `src/bindings/`.
+- **`check:basic-tokens`** — `src/js/utils/basic-tokens.js` is still in step with
+  `src/core/basic/basic_tokens.hpp`, which generates it
+  (`npm run generate:basic-tokens`).
 
 ## Usage
 
@@ -269,6 +283,16 @@ Agent capabilities include: emulator power/reset, BASIC program editing and exec
 See the [AI Agent wiki page](wiki/AI-Agent.md) for full details.
 
 ## Testing
+
+### JavaScript Tests
+
+Vitest, covering the printer emulation, the Applesoft listing parser, and input
+mapping:
+
+```bash
+npm test              # single run
+npm run test:watch    # re-run on change
+```
 
 ### CPU Compliance Tests
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // Enables offline functionality by caching app assets
 
 // IMPORTANT: Bump this version when WASM or core JS files change
-const CACHE_VERSION = 3.5;
+const CACHE_VERSION = 3.6;
 const CACHE_NAME = `a2e-cache-v${CACHE_VERSION}`;
 
 // Files that should always be fetched fresh (network-first).

--- a/src/js/config/version.js
+++ b/src/js/config/version.js
@@ -5,4 +5,4 @@
  *  Mike Daley <michael_daley@icloud.com>
  */
 
-export const VERSION = "1.1.5";
+export const VERSION = "1.1.6";

--- a/src/js/help/release-notes.js
+++ b/src/js/help/release-notes.js
@@ -11,6 +11,84 @@
 
 export const RELEASE_NOTES = [
   {
+    week: "July 27, 2026",
+    features: [],
+    fixes: [
+      {
+        title: "Left and right Alt now select different Apple keys",
+        description:
+          "Left Alt is Open Apple and right Alt is Closed Apple, matching AppleWin and Apple2TS. Both sides report the same key code, so the two are told apart by which side of the keyboard the key is on. The Windows and Context Menu keys are no longer mapped, as the operating system intercepts them before the browser sees them. Contributed by @anomixer.",
+      },
+      {
+        title: "Closed Apple could stick down",
+        description:
+          "Releasing right Alt while Ctrl was held released Open Apple instead, leaving Closed Apple pressed until the key was tapped again.",
+      },
+      {
+        title: "The emulator ran fast after continuing from a breakpoint",
+        description:
+          "Typing text into the emulator temporarily runs it at 8x. A breakpoint hit while characters were still queued left that speed-up in place, so the emulator sprinted as soon as it was resumed.",
+      },
+      {
+        title: "BASIC listings indented everything after a one-line FOR/NEXT",
+        description:
+          "A line that both opened and closed a loop, such as FOR I = 1 TO 5 : NEXT, left every following line indented for the rest of the listing.",
+      },
+      {
+        title: "BASIC listings stopped at 4096 lines",
+        description:
+          "Longer programs were silently truncated part way through. Listings are now limited only by the overall output size.",
+      },
+      {
+        title: "Statement highlighting disagreed with statement breakpoints",
+        description:
+          "On lines containing DATA, the highlighted statement and the statement a breakpoint stopped on were counted by different rules and could differ. Both now use the same one.",
+      },
+      {
+        title: "Programs loaded into memory could start with tracing switched on",
+        description:
+          "Under ProDOS, a stale trace flag survived and printed a line number before every statement. Multiple spaces inside string literals were also collapsed when loading.",
+      },
+      {
+        title: "Menus let screen text bleed through",
+        description:
+          "Menu backgrounds are now opaque.",
+      },
+      {
+        title: "Redeploys were not always picked up",
+        description:
+          "The service worker now revalidates the page on each load, so a new version appears without clearing the browser cache.",
+      },
+      {
+        title: "Open and Save in the editors on Safari and Firefox",
+        description:
+          "Both now fall back to a download and file picker where the File System Access API is unavailable.",
+      },
+    ],
+    improvements: [
+      {
+        title: "Faster BASIC variable inspector",
+        description:
+          "Variables and arrays are now read in bulk rather than a byte at a time. A thousand-element array previously took thousands of separate reads to display.",
+      },
+      {
+        title: "Formatted BASIC listings",
+        description:
+          "Listings shown in the BASIC window and returned to AI agents now carry FOR/NEXT indentation and spacing around operators.",
+      },
+      {
+        title: "More documentation",
+        description:
+          "Added Workspace, Expansion Slots, and Joystick/Paddles sections to the in-app help.",
+      },
+      {
+        title: "Consolidated Applesoft handling",
+        description:
+          "Tokenizing, detokenizing, variable decoding, and statement parsing now have a single implementation shared by the emulator and its tools, with automated tests covering each. Several of the fixes above came from removing duplicates that had drifted apart.",
+      },
+    ],
+  },
+  {
     week: "July 12, 2026",
     features: [],
     fixes: [


### PR DESCRIPTION
Version bump, release notes, and the doc updates the release process calls for.

## Release notes

Cover everything since the last entry, which was written in `189304c` — so as well as this cycle's work, they pick up four commits from 12 July that landed *after* the notes, plus the 18 July menu fix:

- BASIC: one-line `FOR`/`NEXT` indentation, 4096-line listing truncation, statement highlighting vs breakpoints on DATA lines, stale trace flag under ProDOS, collapsed spaces in string literals
- Joystick: left/right Alt selecting different Apple keys — **credited to @anomixer**, who contributed it in #26 — and the stuck Closed Apple bug
- Timing: the emulator running fast after continuing from a breakpoint
- Menus letting screen text bleed through
- Service-worker redeploy pickup, and editor Open/Save fallback on Safari and Firefox
- Improvements: faster variable inspector, formatted BASIC listings, more in-app documentation, and consolidated Applesoft handling

## Docs

- **README** — `npm test` and `npm run check`, plus a JavaScript Tests section
- **CLAUDE.md** — Vitest and consistency-check sections, and the two new core modules from this cycle: `applesoft_vars` (Applesoft variable model) and `debug_log` (host-installed log sink)

## Service worker

Cache bumped 3.5 → 3.6. Its own header asks for this whenever WASM or core JS changes, and both did this cycle. `index.html` is network-first since 12 July, so a stale cache is less punishing than it used to be, but the WASM is still cached and needs the bump to be re-fetched.

## Testing

- C++ 40/40, JS 65/65
- `npm run check` green
- `npm run build` clean; `dist/` carries 1.1.6 and cache v3.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)