### PR TITLE
Joystick window: show real button state on the PB0/PB1 LEDs

### DIFF
--- a/src/js/input/joystick-window.js
+++ b/src/js/input/joystick-window.js
@@ -7,6 +7,26 @@
 
 import { BaseWindow } from "../windows/base-window.js";
 
+// Soft switch state bits for the Apple buttons, matching soft-switch-window.js.
+const BTN0_BIT = 24; // $C061 Open Apple
+const BTN1_BIT = 25; // $C062 Closed Apple
+
+// Fast enough to feel instant on a key press without polling every frame.
+const BUTTON_POLL_MS = 50;
+
+/**
+ * Extract the two Apple button states from a soft switch word.
+ *
+ * @param {number} state  Low 32 bits from _getSoftSwitchState()
+ * @returns {{button0: boolean, button1: boolean}}
+ */
+export function buttonsFromSoftSwitchState(state) {
+  return {
+    button0: (state & (1 << BTN0_BIT)) !== 0,
+    button1: (state & (1 << BTN1_BIT)) !== 0,
+  };
+}
+
 export class JoystickWindow extends BaseWindow {
   constructor(wasmModule) {
     super({
@@ -22,12 +42,58 @@ export class JoystickWindow extends BaseWindow {
     this.isDraggingKnob = false;
     this.knobX = 0.5; // 0-1 range, 0.5 = center
     this.knobY = 0.5;
-    this.button0Pressed = false;
+    this.button0Pressed = false; // mouse is holding this button down
     this.button1Pressed = false;
+    this.buttonPollTimer = null;
     this.gamepadHandler = null;
     this.cursorKeysEnabled = localStorage.getItem("joystick-cursor-keys") === "true";
     this.cursorKeysState = { left: false, right: false, up: false, down: false };
     this.onCursorKeysChanged = null; // callback when toggle changes
+  }
+
+  /**
+   * Reflect the emulator's real button state on the PB0/PB1 LEDs.
+   *
+   * The LEDs used to be driven purely by mouse events on these buttons, so
+   * pressing Open or Closed Apple on the keyboard — or a gamepad button — lit
+   * nothing. Reading $C061/$C062 back means the indicators show the actual
+   * hardware state whatever pressed it.
+   *
+   * Bits 24 and 25 of the soft switch state are BTN0 and BTN1, the same source
+   * the Soft Switch Monitor reads, so this needs no new WASM export.
+   */
+  async updateButtonIndicators() {
+    if (!this.isVisible || !this.wasmModule) return;
+
+    const { button0, button1 } = buttonsFromSoftSwitchState(
+      await this.wasmModule._getSoftSwitchState(),
+    );
+
+    this.button0Element?.classList.toggle("pressed", button0);
+    this.button1Element?.classList.toggle("pressed", button1);
+  }
+
+  startButtonPolling() {
+    if (this.buttonPollTimer) return;
+    this.buttonPollTimer = setInterval(() => this.updateButtonIndicators(), BUTTON_POLL_MS);
+  }
+
+  stopButtonPolling() {
+    if (!this.buttonPollTimer) return;
+    clearInterval(this.buttonPollTimer);
+    this.buttonPollTimer = null;
+  }
+
+  show() {
+    super.show();
+    this.startButtonPolling();
+  }
+
+  hide() {
+    // Nothing to poll for while hidden, and a held button would otherwise stay
+    // lit behind the scenes.
+    this.stopButtonPolling();
+    super.hide();
   }
 
   renderContent() {

--- a/tests/js/input/joystick-buttons.test.js
+++ b/tests/js/input/joystick-buttons.test.js
@@ -1,0 +1,37 @@
+/*
+ * joystick-buttons.test.js - Apple button state from the soft switch word
+ *
+ * Written by
+ *  Mike Daley <michael_daley@icloud.com>
+ */
+
+import { describe, it, expect } from "vitest";
+import { buttonsFromSoftSwitchState } from "../../../src/js/input/joystick-window.js";
+
+// BTN0 ($C061) and BTN1 ($C062) are bits 24 and 25, matching soft-switch-window.js
+const BTN0 = 1 << 24;
+const BTN1 = 1 << 25;
+
+describe("buttonsFromSoftSwitchState", () => {
+  it("reports both buttons released for a zero word", () => {
+    expect(buttonsFromSoftSwitchState(0)).toEqual({ button0: false, button1: false });
+  });
+
+  it("picks out each button independently", () => {
+    expect(buttonsFromSoftSwitchState(BTN0)).toEqual({ button0: true, button1: false });
+    expect(buttonsFromSoftSwitchState(BTN1)).toEqual({ button0: false, button1: true });
+    expect(buttonsFromSoftSwitchState(BTN0 | BTN1)).toEqual({ button0: true, button1: true });
+  });
+
+  it("ignores unrelated switches", () => {
+    // Every other bit set: neither button should read as pressed.
+    const others = ~(BTN0 | BTN1);
+    expect(buttonsFromSoftSwitchState(others)).toEqual({ button0: false, button1: false });
+  });
+
+  it("is not confused by the sign bit", () => {
+    // Bit 31 makes the word negative in JS, which naive masking can trip over.
+    const withSignBit = (BTN1 | (1 << 31)) | 0;
+    expect(buttonsFromSoftSwitchState(withSignBit)).toEqual({ button0: false, button1: true });
+  });
+});


### PR DESCRIPTION
The PB0/PB1 indicators were driven purely by `mousedown`/`mouseup` on the on-screen buttons, so pressing Open or Closed Apple **on the keyboard lit nothing** — the Soft Switch Monitor was the only place to see it. Gamepad buttons were invisible too.

Came up while working out how to test the Alt key changes from #26/#33: the Joystick window is the obvious place to look, and it was the one place that wouldn't show them.

## What changed

The window polls `$C061`/`$C062` while it is open and drives the LEDs from that, so they reflect actual hardware state whatever pressed it — keyboard, mouse, or gamepad.

Bits 24 and 25 of the soft switch word are BTN0 and BTN1, the same source `soft-switch-window.js` reads, so **no new WASM export was needed**.

## Lifecycle

Polling starts in `show()` and stops in `hide()`. `restoreState()` routes through `show()`, so a window left open across a reload starts polling as well.

The mouse handlers still set the class directly for instant feedback — the poll agrees with them, since a mouse press sets the same state the poll reads back.

## Tests

The bit extraction is an exported `buttonsFromSoftSwitchState()` with four tests, including that bit 31 making the word negative in JS doesn't confuse the mask, and that unrelated switches being set doesn't produce false positives.

## Testing

- JS 69/69 (adds 4)
- `npm run check` green; vite build clean

Not exercised in a browser yet — the LEDs should now follow Left Alt and Right Alt the same way the Soft Switch Monitor's BTN0/BTN1 do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)