### PR TITLE
Release 1.1.7

### DIFF
--- a/src/js/config/version.js
+++ b/src/js/config/version.js
@@ -5,4 +5,4 @@
  *  Mike Daley <michael_daley@icloud.com>
  */
 
-export const VERSION = "1.1.6";
+export const VERSION = "1.1.7";

--- a/src/js/help/release-notes.js
+++ b/src/js/help/release-notes.js
@@ -67,6 +67,11 @@ export const RELEASE_NOTES = [
     ],
     improvements: [
       {
+        title: "Joystick window shows live button state",
+        description:
+          "The PB0 and PB1 indicators now light for Open and Closed Apple however they are pressed — keyboard, on-screen button, or gamepad. Previously they only responded to clicking the on-screen buttons, so keyboard presses showed nothing.",
+      },
+      {
         title: "Faster BASIC variable inspector",
         description:
           "Variables and arrays are now read in bulk rather than a byte at a time. A thousand-element array previously took thousands of separate reads to display.",


### PR DESCRIPTION
Ships the live PB0/PB1 indicators in the Joystick window (#35).

## Release notes

The notes are organised by week, and this is the same week as 1.1.6, so the item joins the existing 27 July improvements rather than opening a near-duplicate entry:

> **Joystick window shows live button state** — The PB0 and PB1 indicators now light for Open and Closed Apple however they are pressed — keyboard, on-screen button, or gamepad. Previously they only responded to clicking the on-screen buttons, so keyboard presses showed nothing.

## Service worker cache: deliberately left at 3.6

`public/sw.js` asks for a bump whenever WASM or core JS changes, so this is a considered exception rather than an oversight.

Nothing in `PRECACHE_ASSETS` is content-hashed. `index.html` is network-first, and the app bundles carry content hashes — so a new bundle is a new URL and gets fetched regardless. Bumping the cache would evict everything and make every user re-download the 724 KB WASM for a JavaScript-only change.

## Testing

- JS 69/69
- `npm run check` green
- `npm run build` clean; `dist/` carries 1.1.7

No README or CLAUDE.md changes — nothing structural moved this cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)