### PR TITLE
Fix an Apple button sticking when both Alt keys are held

### DIFF
--- a/src/js/input/input-handler.js
+++ b/src/js/input/input-handler.js
@@ -12,6 +12,40 @@ const PAUSED_POLL_MS = 50;
 // Right Alt reports location 2; left reports 1, and 0 means the browser did not
 // say, which we treat as left. Both sides share keyCode 18, so this is the only
 // thing separating Open Apple from Closed Apple.
+const ALT_SIDES = ["left", "right"];
+
+// Apple button keycodes as the core understands them: 18 is Open Apple, 91 is
+// Closed Apple.
+const ALT_KEYCODE = { left: 18, right: 91 };
+
+/**
+ * Work out which Alt sides should now be reported as released.
+ *
+ * Browsers do not reliably attribute a keyup to the correct side when both Alt
+ * keys are held — the released key can arrive with the other side's location,
+ * or none at all. Trusting a single keyup therefore clears the wrong Apple
+ * button and leaves the released one latched.
+ *
+ * So rather than toggling one side, every Alt release recomputes what is still
+ * held and releases everything else. Releasing an already-released button is a
+ * no-op in the core, which makes this self-correcting: the next Alt event fixes
+ * any earlier mis-attribution.
+ *
+ * @param {Set<string>} sidesDown        sides currently believed to be held
+ * @param {string} releasedSide          side this keyup reported
+ * @param {boolean} anyAltStillHeld      event.altKey at keyup time
+ * @returns {{held: Set<string>, release: string[]}}
+ */
+export function reconcileAltRelease(sidesDown, releasedSide, anyAltStillHeld) {
+  const held = new Set(sidesDown);
+  held.delete(releasedSide);
+
+  // altKey false means no Alt remains down at all, whatever we thought.
+  if (!anyAltStillHeld) held.clear();
+
+  return { held, release: ALT_SIDES.filter((side) => !held.has(side)) };
+}
+
 export function isRightAlt(event) {
   return event.location === 2;
 }
@@ -32,6 +66,7 @@ export class InputHandler {
     this.pasteTimer = null;
     this.pasteSpeedUp = false; // whether we've set a speed multiplier for paste
     this.pasteMultiplier = 1;  // boost the current queue asked for
+    this.altSidesDown = new Set(); // which Alt keys we believe are held
     this.savedSpeedMultiplier = 1; // speed before paste started
 
     // MessageChannel for zero-delay batch scheduling (avoids setTimeout's ~4ms minimum)
@@ -103,6 +138,10 @@ export class InputHandler {
       }
     });
 
+    // A key held while switching away never delivers its keyup, which would
+    // otherwise leave an Apple button latched until it was pressed again.
+    window.addEventListener("blur", () => this.releaseAllAltButtons());
+
     // Paste event listener
     document.addEventListener("paste", (e) => {
       if (
@@ -143,8 +182,10 @@ export class InputHandler {
       // would interfere with typing accented characters.
       if (!ctrl && !meta) event.preventDefault();
 
+      const side = isRightAlt(event) ? "right" : "left";
+      this.altSidesDown.add(side);
       this.wasmModule._handleRawKeyDown(
-        isRightAlt(event) ? 91 : 18,
+        ALT_KEYCODE[side],
         shift, ctrl, alt, meta, capsLock,
       );
       return;
@@ -176,6 +217,14 @@ export class InputHandler {
     this.wasmModule._handleRawKeyDown(keyCode, shift, ctrl, alt, meta, capsLock);
   }
 
+  /** Drop both Apple buttons and forget which Alt keys we thought were held. */
+  releaseAllAltButtons() {
+    this.altSidesDown.clear();
+    for (const side of ALT_SIDES) {
+      this.wasmModule._handleRawKeyUp(ALT_KEYCODE[side], false, false, false, false);
+    }
+  }
+
   handleKeyUp(event) {
     const keyCode = event.keyCode || event.which;
 
@@ -185,12 +234,19 @@ export class InputHandler {
     const alt = event.altKey;
     const meta = event.metaKey;
 
-    // Release joystick buttons — mirrors the keydown mapping above.
+    // Release joystick buttons. Both sides are reconciled rather than toggling
+    // the one this event named — see reconcileAltRelease.
     if (keyCode === 18) {
-      this.wasmModule._handleRawKeyUp(
-        isRightAlt(event) ? 91 : 18,
-        shift, ctrl, alt, meta,
+      const { held, release } = reconcileAltRelease(
+        this.altSidesDown,
+        isRightAlt(event) ? "right" : "left",
+        alt,
       );
+      this.altSidesDown = held;
+
+      for (const side of release) {
+        this.wasmModule._handleRawKeyUp(ALT_KEYCODE[side], shift, ctrl, alt, meta);
+      }
       return;
     }
     // Win / Context Menu → ignore release

--- a/tests/js/input/alt-release.test.js
+++ b/tests/js/input/alt-release.test.js
@@ -1,0 +1,61 @@
+/*
+ * alt-release.test.js - Reconciling Alt key releases to Apple buttons
+ *
+ * Written by
+ *  Mike Daley <michael_daley@icloud.com>
+ */
+
+import { describe, it, expect } from "vitest";
+import { reconcileAltRelease } from "../../../src/js/input/input-handler.js";
+
+const both = () => new Set(["left", "right"]);
+
+describe("reconcileAltRelease", () => {
+  it("keeps the other side held when one of two is released", () => {
+    // The bug this exists for: releasing left while right is still down used to
+    // clear the wrong button and leave Closed Apple latched.
+    const { held, release } = reconcileAltRelease(both(), "left", true);
+
+    expect([...held]).toEqual(["right"]);
+    expect(release).toEqual(["left"]);
+  });
+
+  it("releases both when the last Alt goes up", () => {
+    const { held, release } = reconcileAltRelease(new Set(["right"]), "right", false);
+
+    expect(held.size).toBe(0);
+    expect(release).toEqual(["left", "right"]);
+  });
+
+  it("clears everything when altKey says nothing is held, whatever we believed", () => {
+    // Self-correcting: if an earlier keyup was attributed to the wrong side, our
+    // idea of what is down is stale. altKey false is authoritative.
+    const { held, release } = reconcileAltRelease(both(), "left", false);
+
+    expect(held.size).toBe(0);
+    expect(release).toEqual(["left", "right"]);
+  });
+
+  it("still releases a side we never saw pressed", () => {
+    // A keyup arriving for a side with no matching keydown must not latch it.
+    const { held, release } = reconcileAltRelease(new Set(), "right", false);
+
+    expect(held.size).toBe(0);
+    expect(release).toEqual(["left", "right"]);
+  });
+
+  it("does not mutate the set it is given", () => {
+    const original = both();
+    reconcileAltRelease(original, "left", true);
+
+    expect([...original].sort()).toEqual(["left", "right"]);
+  });
+
+  it("releasing the same side twice is stable", () => {
+    const first = reconcileAltRelease(both(), "left", true);
+    const second = reconcileAltRelease(first.held, "left", true);
+
+    expect([...second.held]).toEqual(["right"]);
+    expect(second.release).toEqual(["left"]);
+  });
+});


### PR DESCRIPTION
Holding both Alt keys and releasing one left the other latched until it was pressed and released again.

## Cause

Each keyup toggled exactly the side the event named:

```js
this.wasmModule._handleRawKeyUp(isRightAlt(event) ? 91 : 18, ...);
```

Browsers do not reliably attribute a modifier keyup to the correct side when both are held — the released key can arrive carrying the other side's `location`, or none at all. So the wrong Apple button was cleared and the genuinely released one stayed down.

The C++ side is not at fault: `handleRawKeyUp` already re-syncs *both* buttons from the keyboard flags (`emulator.cpp:587-588`). It was being told the wrong key went up.

## Fix

Rather than trusting a single keyup, every Alt release now recomputes which sides are still held and releases everything else.

Releasing an already-released button is a no-op in the core, which makes this self-correcting — any earlier mis-attribution is fixed by the next Alt event, and `event.altKey` being false clears both regardless of what we believed was down.

## Also: released on blur

A key held while switching away never delivers its keyup, which latched a button until it was pressed again — the same symptom by a different route. `window` blur now releases both.

## Tests

The decision is an exported `reconcileAltRelease()` with six cases:

- one of two sides released — the other stays held (the reported bug)
- the last side released — both released
- `altKey` disagreeing with our tracked state — `altKey` wins
- a keyup for a side never seen pressed — must not latch it
- the caller's set is not mutated
- releasing the same side twice is stable

## Testing

- JS 75/75 (adds 6)
- `npm run check` green; vite build clean

Not exercised in a browser. Worth checking the original repro — hold both, release one, confirm the other stays lit in the Joystick window and clears when released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)