### PR TITLE
Release 1.1.8

### DIFF
--- a/src/js/config/version.js
+++ b/src/js/config/version.js
@@ -5,4 +5,4 @@
  *  Mike Daley <michael_daley@icloud.com>
  */
 
-export const VERSION = "1.1.7";
+export const VERSION = "1.1.8";

--- a/src/js/help/release-notes.js
+++ b/src/js/help/release-notes.js
@@ -15,6 +15,11 @@ export const RELEASE_NOTES = [
     features: [],
     fixes: [
       {
+        title: "Apple buttons could stick down",
+        description:
+          "Releasing right Alt while Ctrl was held cleared the wrong button, and holding a key while switching to another window never released it at all — either way the button stayed pressed until it was tapped again. Key handling now derives the buttons from which keys are actually held rather than toggling them, so a missed or misreported release cannot latch one on. Note that macOS browsers report nothing when one of two held Option keys is released, so that button stays down until the second key is released; this cannot be detected by a web page.",
+      },
+      {
         title: "Left and right Alt now select different Apple keys",
         description:
           "Left Alt is Open Apple and right Alt is Closed Apple, matching AppleWin and Apple2TS. Both sides report the same key code, so the two are told apart by which side of the keyboard the key is on. The Windows and Context Menu keys are no longer mapped, as the operating system intercepts them before the browser sees them. Contributed by @anomixer.",


### PR DESCRIPTION
Ships the Apple button sticking fixes (#37) and the move of Alt key handling into the core (#38).

The live site is currently on 1.1.7, which predates both, so this is the release that actually gets the fixes to users.

## Release note

Joins the existing 27 July fixes, since the notes are organised by week:

> **Apple buttons could stick down** — Releasing right Alt while Ctrl was held cleared the wrong button, and holding a key while switching to another window never released it at all — either way the button stayed pressed until it was tapped again. Key handling now derives the buttons from which keys are actually held rather than toggling them, so a missed or misreported release cannot latch one on. Note that macOS browsers report nothing when one of two held Option keys is released, so that button stays down until the second key is released; this cannot be detected by a web page.

The note is deliberately honest about the part that cannot be fixed. Better users know than report it again.

## Service worker cache: staying at 3.6

The WASM genuinely did change this time, which is normally the trigger to bump. It is still unnecessary:

- `/a2e.wasm` and `/a2e.js` are both in `NETWORK_FIRST_FILES`, so they are always refetched
- `index.html` is network-first
- the app bundles are content-hashed, so a new build is a new URL

Nothing stale can be served, and a bump would evict every cache for no benefit.

## Testing

- C++ 40/40, JS 65/65
- `npm run check` green
- `npm run build` clean; `dist/` carries 1.1.8 and a freshly built WASM

🤖 Generated with [Claude Code](https://claude.com/claude-code)