### PR TITLE
Align slot hint labels and defaults with Apple's conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -259,7 +259,7 @@ The MMU supports pluggable expansion cards matching real Apple IIe hardware. Car
 | 4    | $C0C0-$C0CF | $C400-$C4FF | Mockingboard                |
 | 5    | $C0D0-$C0DF | $C500-$C5FF | Thunderclock                |
 | 6    | $C0E0-$C0EF | $C600-$C6FF | Disk II                     |
-| 7    | $C0F0-$C0FF | $C700-$C7FF | Empty                       |
+| 7    | $C0F0-$C0FF | $C700-$C7FF | SmartPort                   |
 
 ### Card Interface Methods
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Cards are configured via **View > Expansion Slots**.
 | 4 | Mockingboard | Mouse Card, SmartPort, Z-80 SoftCard, Empty |
 | 5 | Thunderclock Plus | SmartPort, Z-80 SoftCard, Empty |
 | 6 | Disk II | Empty |
-| 7 | Empty | Thunderclock Plus, SmartPort, Z-80 SoftCard |
+| 7 | SmartPort | Thunderclock Plus, Z-80 SoftCard, Empty |
 
 **Mockingboard** — Dual AY-3-8910 sound chips with VIA 6522 timers. Stereo output with per-channel mute controls. All audio (speaker, Mockingboard, drive sounds) is unified under a single volume slider and mute toggle.
 

--- a/src/js/ui/slot-configuration-window.js
+++ b/src/js/ui/slot-configuration-window.js
@@ -58,13 +58,13 @@ export class SlotConfigurationWindow extends BaseWindow {
         slot: 1,
         label: "Slot 1",
         available: ["parallel", "ssc", "softcard"],
-        note: "Printer / Serial",
+        note: "Printer",
       },
       {
         slot: 2,
         label: "Slot 2",
         available: ["parallel", "ssc", "smartport", "softcard"],
-        note: "Serial / Modem",
+        note: "Modem / Serial",
       },
       {
         slot: 3,
@@ -77,20 +77,20 @@ export class SlotConfigurationWindow extends BaseWindow {
         slot: 4,
         label: "Slot 4",
         available: ["mockingboard", "mouse", "smartport", "softcard"],
-        note: "Sound / Mouse",
+        note: "Mouse / Sound",
       },
       {
         slot: 5,
         label: "Slot 5",
         available: ["thunderclock", "smartport", "softcard"],
-        note: "Clock / Drive",
+        note: "3.5\" Drives / Clock",
       },
-      { slot: 6, label: "Slot 6", available: ["disk2"], note: "Disk drives" },
+      { slot: 6, label: "Slot 6", available: ["disk2"], note: "5.25\" Drives" },
       {
         slot: 7,
         label: "Slot 7",
         available: ["thunderclock", "smartport", "softcard"],
-        note: "RAM / Clock",
+        note: "Hard Disk / Clock",
       },
     ];
 
@@ -553,7 +553,7 @@ export class SlotConfigurationWindow extends BaseWindow {
 
   async applyInitialSettings() {
     const saved = this.loadSettingsFromStorage();
-    const config = saved || { 4: "mockingboard", 5: "smartport", 6: "disk2", 7: "thunderclock" };
+    const config = saved || { 4: "mockingboard", 5: "thunderclock", 6: "disk2", 7: "smartport" };
     if (this.wasmModule && this.wasmModule._setSlotCard) {
       for (const [slot, cardId] of Object.entries(config)) {
         const slotNum = parseInt(slot, 10);


### PR DESCRIPTION
## Summary

The right-hand hint labels in the Expansion Slots window were partly at odds with Apple's documented slot assignments, and two of them advertised hardware the emulator doesn't offer. This aligns them with the conventions, and swaps the default layout to match.

## Label changes

| Slot | Was | Now | Why |
|---|---|---|---|
| 1 | Printer / Serial | **Printer** | Slot 1 is the printer slot; both cards allowed there (Parallel, SSC) are printer interfaces here, so "Serial" was redundant. |
| 2 | Serial / Modem | **Modem / Serial** | Slot 2 is the modem slot — leading with the convention. |
| 3 | 80-Column (Built-in) | *unchanged* | Already correct. |
| 4 | Sound / Mouse | **Mouse / Sound** | Slot 4 is *the* mouse slot. Mockingboard's slot-4 default is a strong de-facto standard too, so both belong — just in Apple's order. |
| 5 | Clock / Drive | **3.5" Drives / Clock** | Slot 5 is the SmartPort convention (built into the IIgs, where ProDOS issues a SmartPort STATUS call specifically at `$C500`). "Drive" didn't distinguish it from slot 6. |
| 6 | Disk drives | **5.25" Drives** | Matches the TIL wording, contrasts properly with slot 5, and fixes the odd sentence case. |
| 7 | RAM / Clock | **Hard Disk / Clock** | There is no RAM card in the tray, so "RAM" pointed at nothing. Slot 7 is the conventional hard-disk/boot slot, which is what SmartPort is here. |

Thunderclock keeps a secondary billing on slots 5 and 7 rather than an authoritative one: it has no canonical slot — the manual says any slot 1–7 and ProDOS auto-detects it.

## Default layout

SmartPort moves to slot 7 and Thunderclock to slot 5, matching the conventions above.

- Only affects installs with **no saved `a2e-slot-config`** — existing users keep their layout.
- Both slots already listed both cards as compatible, in the UI and in `agent/slot-tools.js`, so no compatibility changes were needed.
- Side effect worth noting: slot 7 taking SmartPort means a SmartPort image now has boot priority over the Disk II in slot 6, since the //e boots the highest-numbered bootable slot.

`CLAUDE.md` and `README.md` slot tables both still listed slot 7 as empty; updated.

## Sources

- [Apple TIL 15762 — Apple IIe/IIgs: Slot Assignments](https://archive.org/stream/IIe_IIgs_slot_assignments/IIe_IIgs_slot_assignments_djvu.txt)
- [ProDOS 8 Technical Note #21 (SmartPort)](https://prodos8.com/docs/technote/21/)
- [ThunderClock Plus manual](https://mirrors.apple2.org.za/ftp.apple.asimov.net/documentation/hardware/clocks/ThunderClock%20Plus.pdf)

## Testing

`npm test` — 65 passed. Labels and defaults are data-only changes with no test coverage; verified the module still parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)