### PR TITLE
Release 1.1.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A cycle-accurate Apple //e Enhanced emulator running in the browser using WebAss
 - **Expansion cards** — Mockingboard sound card, Thunderclock Plus, Apple Mouse Interface Card, SmartPort hard drive, Super Serial Card, Parallel Card (Centronics), Microsoft Z-80 SoftCard, No-Slot Clock (DS1215)
 - **Virtual dot-matrix printer** — ImageWriter II (colour), ImageWriter I, Epson FX-80, and Apple DMP with period-correct fonts, sounds, and PNG/PDF export
 - **File explorer** — Browse DOS 3.3 and ProDOS disk contents with BASIC detokenizer and disassembler
+- **Shareable links** — Pass a disk image URL in the address (`?disk=`) to open the emulator with it already loaded
 - **Save states** — Autosave slot plus 5 manual save slots, stored in IndexedDB
 - **Built-in debugger** — CPU debugger, memory browser, heat map, soft switch monitor, BASIC conditional breakpoints, and more
 - **Light/Dark/System themes** — Switchable colour scheme with Apple rainbow logo accent palette

--- a/src/js/config/version.js
+++ b/src/js/config/version.js
@@ -5,4 +5,4 @@
  *  Mike Daley <michael_daley@icloud.com>
  */
 
-export const VERSION = "1.1.8";
+export const VERSION = "1.1.9";

--- a/src/js/help/release-notes.js
+++ b/src/js/help/release-notes.js
@@ -11,6 +11,29 @@
 
 export const RELEASE_NOTES = [
   {
+    week: "July 28, 2026",
+    features: [
+      {
+        title: "Share a link that opens with a disk already loaded",
+        description:
+          "Add a disk image URL to the address and the emulator starts with it in the drive: ?disk= for drive 1, ?disk2= for drive 2, ?hd= and ?hd2= for the SmartPort devices. Images hosted alongside the emulator can use a plain path, such as ?disk=/disks/demo.dsk. Disks loaded this way are not saved to your browser storage or your Recent list, and autosave pauses for the session, so a link someone sends you never replaces the disks in your own drives — open the plain address again and everything is as you left it. The file's host has to allow other sites to read it, which GitHub, Google Drive and Dropbox do but most classic archive mirrors do not; where a URL has no filename, ?name= supplies one, which .nib and .2mg images need.",
+      },
+    ],
+    fixes: [],
+    improvements: [
+      {
+        title: "Expansion slot hints follow Apple's slot assignments",
+        description:
+          "The hints beside each slot now match Apple's documented conventions — slot 1 printer, slot 2 modem, slot 4 mouse, slot 5 3.5\" drives, slot 7 hard disk — instead of listing secondary uses first. Slot 7 no longer suggests a RAM card, which the emulator does not offer.",
+      },
+      {
+        title: "SmartPort now starts in slot 7 and Thunderclock in slot 5",
+        description:
+          "Matches the conventional layout, where slot 7 is the hard disk and boot slot. Only affects a first visit; a slot layout you have already applied is left alone.",
+      },
+    ],
+  },
+  {
     week: "July 27, 2026",
     features: [],
     fixes: [


### PR DESCRIPTION
Bumps `VERSION` to 1.1.9 and adds the release notes entry for July 28, 2026.

## Included since 1.1.8

**Feature — shareable links (#41, closes #7)**
`?disk=`, `?disk2=`, `?hd=`, `?hd2=` and `?name=` load disk images named in the address. Loads are transient: not written to browser storage or Recent, with autosave paused for the session, so a shared link cannot displace the recipient's own disks.

**Improvement — expansion slots (#40)**
Slot hint labels follow Apple TIL 15762 (slot 1 printer, 2 modem, 4 mouse, 5 3.5" drives, 7 hard disk), and slot 7 no longer advertises a RAM card the emulator does not offer. Default layout moves SmartPort to slot 7 and Thunderclock to slot 5; existing saved layouts are untouched.

Also adds `public/disks/IBIZA_II.dsk` as a local image for exercising the `?disk=` parameter. It is not listed in `library.json`, so it does not appear in the Library dropdown.

## Checks

- `npm run check` — 91 tests pass, export/core-purity/token guards clean
- `npm run build` — WASM rebuilt and Vite bundle produced; 1.1.9 confirmed present in the output

🤖 Generated with [Claude Code](https://claude.com/claude-code)