### PR TITLE
Release 1.1.10

### DIFF
--- a/src/js/config/version.js
+++ b/src/js/config/version.js
@@ -5,4 +5,4 @@
  *  Mike Daley <michael_daley@icloud.com>
  */
 
-export const VERSION = "1.1.9";
+export const VERSION = "1.1.10";

--- a/src/js/help/release-notes.js
+++ b/src/js/help/release-notes.js
@@ -11,6 +11,18 @@
 
 export const RELEASE_NOTES = [
   {
+    week: "July 29, 2026",
+    features: [],
+    fixes: [
+      {
+        title: "The emulator could freeze after loading a saved state",
+        description:
+          "Loading a state left the screen stuck on the restored image with no sound, and nothing typed had any effect until the page was clicked. Restoring used to switch the emulator off and on again, which rebuilds the sound system — and the sound card is what paces the emulator, so when the browser held it back until the next click, the machine sat there doing nothing. A machine that is already on now keeps running through the restore. Loading a state from a file also reported success even when the file could not be read.",
+      },
+    ],
+    improvements: [],
+  },
+  {
     week: "July 28, 2026",
     features: [
       {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -613,49 +613,57 @@ class AppleIIeEmulator {
     this._renderFrameCount = 0;
     this._cachedIsPaused = false;
 
+    // Every await in here is a Worker round-trip, and a single rejection would
+    // otherwise skip the requestAnimationFrame below and kill the loop for good
+    // — a black, unrecoverable screen from one transient RPC error. Log it and
+    // keep drawing instead.
     const render = async () => {
-      this._renderFrameCount++;
-      this.windowManager.updateAll(this.wasmModule);
+      try {
+        this._renderFrameCount++;
+        this.windowManager.updateAll(this.wasmModule);
 
-      // Throttle disk LED updates to ~15fps (every 4th frame)
-      if (this._renderFrameCount % 4 === 0) {
-        this.diskManager.drivesWindowVisible = this.windowManager.isWindowVisible('disk-drives');
-        this.diskManager.updateLEDs();
-        if (this.hardDriveManager) {
-          this.hardDriveManager.updateLEDs();
+        // Throttle disk LED updates to ~15fps (every 4th frame)
+        if (this._renderFrameCount % 4 === 0) {
+          this.diskManager.drivesWindowVisible = this.windowManager.isWindowVisible('disk-drives');
+          this.diskManager.updateLEDs();
+          if (this.hardDriveManager) {
+            this.hardDriveManager.updateLEDs();
+          }
         }
-      }
 
-      // Poll pause state from Worker (async, cached for this frame)
-      if (this.running) {
-        this._cachedIsPaused = await this.wasmModule._isPaused();
-      }
-      const isPaused = this.running && this._cachedIsPaused;
+        // Poll pause state from Worker (async, cached for this frame)
+        if (this.running) {
+          this._cachedIsPaused = await this.wasmModule._isPaused();
+        }
+        const isPaused = this.running && this._cachedIsPaused;
 
-      // Beam crosshair overlay — only when CPU debugger is open and CPU is paused
-      if (isPaused && this.cpuDebuggerWindow && this.cpuDebuggerWindow.isVisible) {
-        const [scanline, hPos] = await this.wasmModule.batch([
-          ['_getBeamScanline'], ['_getBeamHPos']
-        ]);
-        this.renderer.setParam("beamY", scanline < 192 ? (scanline + 0.5) / 192.0 : -1.0);
-        this.renderer.setParam("beamX", hPos >= 25 ? (hPos - 25) / 40.0 : -1.0);
-      } else {
-        this.renderer.setParam("beamY", -1.0);
-        this.renderer.setParam("beamX", -1.0);
-      }
-
-      if (this.frameReady) {
-        this.frameReady = false;
-        this.renderFrame();
-      } else if (!this.running || isPaused) {
-        if (isPaused) {
-          await this.wasmModule._forceRenderFrame();
-          // After forcing render, the Worker will send a framebuffer via onFrameReady
-          // On next frame we'll pick it up. For now, re-draw with what we have.
-          this.renderFrame();
+        // Beam crosshair overlay — only when CPU debugger is open and CPU is paused
+        if (isPaused && this.cpuDebuggerWindow && this.cpuDebuggerWindow.isVisible) {
+          const [scanline, hPos] = await this.wasmModule.batch([
+            ['_getBeamScanline'], ['_getBeamHPos']
+          ]);
+          this.renderer.setParam("beamY", scanline < 192 ? (scanline + 0.5) / 192.0 : -1.0);
+          this.renderer.setParam("beamX", hPos >= 25 ? (hPos - 25) / 40.0 : -1.0);
         } else {
-          this.renderer.draw();
+          this.renderer.setParam("beamY", -1.0);
+          this.renderer.setParam("beamX", -1.0);
         }
+
+        if (this.frameReady) {
+          this.frameReady = false;
+          this.renderFrame();
+        } else if (!this.running || isPaused) {
+          if (isPaused) {
+            await this.wasmModule._forceRenderFrame();
+            // After forcing render, the Worker will send a framebuffer via onFrameReady
+            // On next frame we'll pick it up. For now, re-draw with what we have.
+            this.renderFrame();
+          } else {
+            this.renderer.draw();
+          }
+        }
+      } catch (error) {
+        console.error("Render loop error:", error);
       }
 
       requestAnimationFrame(render);

--- a/src/js/state/save-states-window.js
+++ b/src/js/state/save-states-window.js
@@ -356,7 +356,7 @@ export class SaveStatesWindow extends BaseWindow {
 
   handleLoadFromFile(file) {
     const reader = new FileReader();
-    reader.onload = () => {
+    reader.onload = async () => {
       const data = new Uint8Array(reader.result);
 
       // Validate magic bytes
@@ -370,7 +370,7 @@ export class SaveStatesWindow extends BaseWindow {
         return;
       }
 
-      const ok = this.stateManager.restoreFromFileData(data);
+      const ok = await this.stateManager.restoreFromFileData(data);
       if (ok) {
         this.uiController.showNotification("State loaded from file");
         this.uiController.refocusCanvas();

--- a/src/js/state/state-manager.js
+++ b/src/js/state/state-manager.js
@@ -223,14 +223,21 @@ export class StateManager {
       return false;
     }
 
-    // Power cycle: stop and restart the emulator for a clean slate
-    const wasRunning = this.emulator.isRunning();
-    if (wasRunning) {
-      this.emulator.stop();
+    // No power cycle for a machine that is already on. importState() resets the
+    // core itself before unpacking, so stopping and restarting here would only
+    // rebuild the audio stack — and the AudioWorklet is the emulation clock. A
+    // fresh AudioContext built this far from the click that asked for the
+    // restore comes up suspended in some browsers, and AudioDriver.start() then
+    // waits for the *next* click before it builds a worklet. Nothing requests
+    // samples in the meantime, so the emulator sits there looking frozen.
+    const poweredOnHere = !this.emulator.isRunning();
+    if (poweredOnHere) {
+      await this.emulator.start();
+    } else {
+      // start() would have done this. A paste still feeding keys would type
+      // into the restored machine.
+      this.emulator.inputHandler?.cancelPaste();
     }
-
-    // Start fresh
-    this.emulator.start();
 
     // Copy state data to WASM memory
     const statePtr = await this.wasmModule._malloc(stateData.length);
@@ -261,7 +268,12 @@ export class StateManager {
       }
       return true;
     } else {
-      this.emulator.stop();
+      // Only undo the power-on we did ourselves. A machine that was already
+      // running is left alone: importState() rejects a bad magic or version
+      // before it resets anything, so there is nothing to recover from.
+      if (poweredOnHere) {
+        await this.emulator.stop();
+      }
       return false;
     }
   }


### PR DESCRIPTION
Patch release fixing the emulator freezing after a saved state is loaded.

## Fix

Restoring a state power-cycled the emulator, which tears down and rebuilds the audio stack. The AudioWorklet is the emulation clock, and the new `AudioContext` is constructed several awaits after the click that asked for the restore — far enough out that some browsers hand it back suspended. `AudioDriver.start()` then waits for the next click before building a worklet, so nothing requests samples and the machine sits frozen.

The power cycle was redundant anyway: `importState()` resets the core itself before unpacking. A running machine now keeps its clock.

Also in this release:

- `restoreFromFileData()` returns a promise that was dropped, so restoring from a `.a2state` file always reported success even when the import failed.
- The render loop had no error handling; one rejected Worker RPC would skip the `requestAnimationFrame` and kill it permanently — a separate route to the same frozen symptom.

## Verification

`npm run check` passes (exports, core purity, BASIC tokens, 91 JS tests) and the production build is clean.

Not yet reproduced or confirmed in a browser — the diagnosis is from reading the restore path, and the suspended-`AudioContext` mechanism is browser-dependent. Worth a manual check that a state restore still runs, particularly in Safari.

🤖 Generated with [Claude Code](https://claude.com/claude-code)