### PR TITLE
Fix memory browser showing only a single row

### DIFF
--- a/src/css/memory-windows.css
+++ b/src/css/memory-windows.css
@@ -112,6 +112,29 @@
     color: var(--text-muted);
 }
 
+/* The scroll container fills the leftover height with flex: 1, which needs a
+   flex parent to grow into. .debug-window-content is display:block by default,
+   so the container had NO definite height and sized itself to its own content
+   instead — and since recalcVisibleRows() derives the row count from that
+   height, the two fed each other: render N rows, container becomes N rows tall,
+   measure N rows. It latched on the first measurement (4px of scrollbar padding
+   with an empty view, floored to one row) and the window showed a single row of
+   memory forever.
+   The docking layout already made this element a flex column, which is why the
+   bug only showed for a floating window. Same fix as .documentation-window. */
+#memory-browser .debug-window-content {
+    display: flex;
+    flex-direction: column;
+}
+
+/* Toolbar, region label and column header keep their natural height so the
+   scroll container gets everything that is left. */
+#memory-browser .mem-browser-toolbar,
+#memory-browser .mem-browser-region,
+#memory-browser .mem-browser-header {
+    flex-shrink: 0;
+}
+
 .mem-browser-scroll-container {
     display: flex;
     flex: 1;

--- a/src/js/debug/memory-browser-window.js
+++ b/src/js/debug/memory-browser-window.js
@@ -324,12 +324,20 @@ export class MemoryBrowserWindow extends BaseWindow {
     if (!this.contentDiv) return;
     const container = this.contentDiv.parentElement;
     if (!container) return;
-    const height = container.clientHeight;
-    if (height > 0) {
-      // Each row is ~17px (11px font * 1.4 line-height + 2px padding)
-      const rowHeight = 17;
-      this.visibleRows = Math.max(1, Math.floor(height / rowHeight));
-    }
+
+    // Each row is ~17px (11px font * 1.4 line-height + 2px padding)
+    const rowHeight = 17;
+    const rows = Math.floor(container.clientHeight / rowHeight);
+
+    // Ignore a measurement that cannot fit a single row. The container is laid
+    // out to a definite height, so this only happens before layout has run or
+    // while the window is collapsed — and trusting it is dangerous: the row
+    // count drives how much gets rendered, so a bogus small value can become
+    // self-fulfilling and stick. Keeping the previous value means the view
+    // simply re-measures on the next tick.
+    if (rows < 1) return;
+
+    this.visibleRows = rows;
   }
 
   async update(wasmModule) {


### PR DESCRIPTION
## The bug

The Memory Browser rendered exactly one row of memory regardless of window size.

`.mem-browser-scroll-container` fills the leftover height with `flex: 1`, but its parent `.debug-window-content` is `display: block` — so `flex: 1` had nothing to grow into and the container sized itself to **its own content** instead.

That closes a loop with `recalcVisibleRows()`, which derives the row count from that same height:

> render N rows → container becomes N rows tall → measure N rows

It latched on the very first measurement: an empty view is ~4px (just the scrollbar's padding), which floors to one row — and one row is 17px, which measures back as one row. Locked permanently, with no path to recovery.

**Only floating windows were affected.** `docking.css` already makes that element a flex column, so a docked Memory Browser laid out correctly — likely why this went unnoticed.

**Pre-existing**, not from the recent performance work: I reproduced the identical single row after swapping in `memory-browser-window.js` from `9222c7f` (the commit before that work).

## The fix

**`src/css/memory-windows.css`** — make the content element a flex column, following the existing `.documentation-window` precedent, and keep the toolbar, region label and column header from shrinking so the scroll container receives the remaining height:

```css
#memory-browser .debug-window-content { display: flex; flex-direction: column; }
```

**`recalcVisibleRows()`** — ignore a measurement too small to fit one row instead of clamping to `1`. With the layout fixed the container height no longer depends on content, so the loop cannot form; this additionally stops a bogus early measurement from ever becoming self-fulfilling, which is what made the original failure permanent rather than transient.

## Verification

Driven in a real browser:

| Check | Result |
|---|---|
| Rows rendered (620px window) | **27** in a 460px container |
| Resize tracking | 760px → 35 rows, 300px → 8, 620px → 27 |
| Row content | correct bytes, ASCII column, high-bit/zero byte classes applied |
| Region labelling | `$C000` correctly shown as "I/O Space" |
| `jumpToAddress($C000)` | `$C000` – `$C1A0` |
| Console | no errors |

`npm run check` passes (282 exports in sync, 91 tests) and `vite build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
