### PR TITLE
Make all window backgrounds opaque and remove backdrop blur

### DIFF
--- a/src/css/assembler-editor.css
+++ b/src/css/assembler-editor.css
@@ -1185,7 +1185,6 @@
     align-items: center;
     justify-content: center;
     background: rgba(0, 0, 0, 0.5);
-    backdrop-filter: var(--glass-backdrop);
     z-index: 200;
 }
 

--- a/src/css/base.css
+++ b/src/css/base.css
@@ -73,20 +73,19 @@
     --selection-highlight: rgba(24, 171, 234, 0.35);
     --selection-copy-flash: rgba(110, 201, 79, 0.5);
 
-    /* Glassmorphism / overlay semantic tokens */
-    /* Every frosted surface reads its blur from these two tokens rather than
-       hard-coding one, so transparency can be switched off in a single place.
-       This matters more than it looks: these panels float over the emulator
-       canvas, which repaints 60 times a second, so the compositor must re-run
-       the blur over the full area of every open window on every frame whether
-       or not the window's own content changed. Blur cost rises faster than
-       linearly with radius, which is why the panel radius is modest. */
-    --glass-backdrop: blur(6px);
-    --glass-backdrop-strong: blur(12px);
-    --glass-bg: rgba(13, 17, 23, 0.85);
-    --glass-bg-solid: rgba(13, 17, 23, 0.95);
+    /* Window and panel surfaces.
+       These are fully opaque and carry no backdrop blur. They used to be
+       translucent with a backdrop-filter, which looked good but was expensive
+       in a way that never showed up in a JS profile: the panels sit over the
+       emulator canvas, which repaints 60 times a second, so the compositor had
+       to re-run the blur across the full area of every open window on every
+       frame — whether or not that window's own content had changed. Opaque
+       rects cost nothing to composite.
+       The names are kept because ~90 rules reference them. */
+    --glass-bg: rgb(13, 17, 23);
+    --glass-bg-solid: rgb(13, 17, 23);
     --menu-bg-opaque: rgb(18, 23, 30);
-    --glass-bg-header: rgba(33, 38, 45, 0.6);
+    --glass-bg-header: rgb(33, 38, 45);
     --glass-border: rgba(48, 54, 61, 0.6);
     --glass-border-light: rgba(48, 54, 61, 0.4);
     --glass-border-subtle: rgba(48, 54, 61, 0.3);
@@ -277,11 +276,11 @@ html[data-theme="light"] {
     --selection-highlight: rgba(0, 111, 163, 0.2);
     --selection-copy-flash: rgba(58, 125, 41, 0.3);
 
-    /* Glassmorphism */
-    --glass-bg: rgba(255, 255, 255, 0.92);
-    --glass-bg-solid: rgba(255, 255, 255, 0.97);
+    /* Window and panel surfaces — opaque, see the dark theme note above */
+    --glass-bg: rgb(255, 255, 255);
+    --glass-bg-solid: rgb(255, 255, 255);
     --menu-bg-opaque: rgb(255, 255, 255);
-    --glass-bg-header: rgba(246, 248, 250, 0.8);
+    --glass-bg-header: rgb(246, 248, 250);
     --glass-border: rgba(208, 215, 222, 0.8);
     --glass-border-light: rgba(208, 215, 222, 0.6);
     --glass-border-subtle: rgba(208, 215, 222, 0.4);
@@ -433,31 +432,6 @@ html[data-theme="light"] {
     --mem-separator: #afb8c1;
     --mem-scrollbar-thumb: rgba(0, 111, 163, 0.3);
     --mem-scrollbar-thumb-hover: rgba(0, 111, 163, 0.5);
-}
-
-/* ─── Reduced transparency ───────────────────────────────────────────────
-   Turns every frosted panel opaque and drops the backdrop filters entirely.
-   This is the single biggest GPU saving available on a busy desktop: with the
-   filters gone the compositor stops re-blurring each floating window over the
-   emulator canvas 60 times a second, and the panels become cheap opaque rects.
-   Honoured automatically when the OS asks for reduced transparency, and
-   available as an explicit toggle in Display Settings. */
-html[data-reduce-transparency="true"] {
-    --glass-backdrop: none;
-    --glass-backdrop-strong: none;
-    --glass-bg: var(--glass-bg-solid);
-    --glass-bg-header: var(--bg-medium);
-    --menu-bg-opaque: var(--bg-medium);
-}
-
-@media (prefers-reduced-transparency: reduce) {
-    html:not([data-reduce-transparency="false"]) {
-        --glass-backdrop: none;
-        --glass-backdrop-strong: none;
-        --glass-bg: var(--glass-bg-solid);
-        --glass-bg-header: var(--bg-medium);
-        --menu-bg-opaque: var(--bg-medium);
-    }
 }
 
 /* Utility classes */

--- a/src/css/controls.css
+++ b/src/css/controls.css
@@ -284,8 +284,6 @@
     left: 0;
     min-width: 200px;
     background: var(--menu-bg-opaque);
-    backdrop-filter: var(--glass-backdrop-strong);
-    -webkit-backdrop-filter: var(--glass-backdrop-strong);
     border: 1px solid var(--glass-border);
     border-radius: var(--radius-md);
     box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);

--- a/src/css/debug-base.css
+++ b/src/css/debug-base.css
@@ -6,8 +6,6 @@
 .debug-window {
     position: fixed;
     background: var(--glass-bg);
-    backdrop-filter: var(--glass-backdrop);
-    -webkit-backdrop-filter: var(--glass-backdrop);
     border: 1px solid var(--glass-border);
     border-radius: var(--radius-md);
     box-shadow: var(--shadow-window);

--- a/src/css/debug-windows.css
+++ b/src/css/debug-windows.css
@@ -6,8 +6,6 @@
 .debug-window {
     position: fixed;
     background: var(--glass-bg);
-    backdrop-filter: var(--glass-backdrop);
-    -webkit-backdrop-filter: var(--glass-backdrop);
     border: 1px solid var(--glass-border);
     border-radius: var(--radius-md);
     box-shadow: var(--shadow-window);
@@ -1545,8 +1543,8 @@
 }
 
 /* No transition on the badges: VBLBAR flips on nearly every sample, and an
-   animated box-shadow repaints the window (and re-blurs its backdrop-filter)
-   for the whole transition duration. Toggling instantly costs one paint. */
+   animated box-shadow repaints the window for the whole transition duration.
+   Toggling instantly costs one paint. */
 .switch-badge {
     min-width: 60px;
     padding: 2px 6px;
@@ -5447,7 +5445,6 @@ input.rb-detail {
     align-items: center;
     justify-content: center;
     background: rgba(0, 0, 0, 0.5);
-    backdrop-filter: var(--glass-backdrop);
     z-index: 200;
 }
 

--- a/src/css/fullscreen-popouts.css
+++ b/src/css/fullscreen-popouts.css
@@ -75,9 +75,7 @@
   align-items: center;
   justify-content: center;
   gap: 4px;
-  background: rgba(10, 10, 11, 0.65);
-  backdrop-filter: var(--glass-backdrop);
-  -webkit-backdrop-filter: var(--glass-backdrop);
+  background: rgb(10, 10, 11);
   color: rgba(255, 255, 255, 0.45);
   cursor: pointer;
   transition: background 0.2s ease, color 0.2s ease;
@@ -99,7 +97,7 @@
 }
 
 .fp-popout-tab:hover {
-  background: rgba(10, 10, 11, 0.85);
+  background: rgb(26, 26, 28);
   color: rgba(255, 255, 255, 0.8);
 }
 
@@ -114,9 +112,7 @@
   flex-direction: column;
   gap: 6px;
   padding: 10px 12px;
-  background: rgba(10, 10, 11, 0.85);
-  backdrop-filter: var(--glass-backdrop);
-  -webkit-backdrop-filter: var(--glass-backdrop);
+  background: rgb(26, 26, 28);
   border: 1px solid rgba(255, 255, 255, 0.25);
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5), 0 0 4px rgba(255, 255, 255, 0.15);
   white-space: nowrap;
@@ -221,9 +217,7 @@
   min-width: 180px;
   max-height: 240px;
   overflow-y: auto;
-  background: rgba(10, 10, 11, 0.92);
-  backdrop-filter: var(--glass-backdrop);
-  -webkit-backdrop-filter: var(--glass-backdrop);
+  background: rgb(10, 10, 11);
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 6px;
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.5);

--- a/src/css/layout.css
+++ b/src/css/layout.css
@@ -10,7 +10,6 @@ header {
     padding: var(--space-sm) var(--space-lg);
     background: var(--bg-medium);
     border-bottom: 1px solid var(--border-default);
-    backdrop-filter: var(--glass-backdrop);
     position: sticky;
     top: 0;
     z-index: 2000;

--- a/src/css/memory-windows.css
+++ b/src/css/memory-windows.css
@@ -112,6 +112,29 @@
     color: var(--text-muted);
 }
 
+/* The scroll container fills the leftover height with flex: 1, which needs a
+   flex parent to grow into. .debug-window-content is display:block by default,
+   so the container had NO definite height and sized itself to its own content
+   instead — and since recalcVisibleRows() derives the row count from that
+   height, the two fed each other: render N rows, container becomes N rows tall,
+   measure N rows. It latched on the first measurement (4px of scrollbar padding
+   with an empty view, floored to one row) and the window showed a single row of
+   memory forever.
+   The docking layout already made this element a flex column, which is why the
+   bug only showed for a floating window. Same fix as .documentation-window. */
+#memory-browser .debug-window-content {
+    display: flex;
+    flex-direction: column;
+}
+
+/* Toolbar, region label and column header keep their natural height so the
+   scroll container gets everything that is left. */
+#memory-browser .mem-browser-toolbar,
+#memory-browser .mem-browser-region,
+#memory-browser .mem-browser-header {
+    flex-shrink: 0;
+}
+
 .mem-browser-scroll-container {
     display: flex;
     flex: 1;

--- a/src/css/modals.css
+++ b/src/css/modals.css
@@ -16,7 +16,6 @@
     justify-content: center;
     gap: var(--space-lg);
     z-index: 1000;
-    backdrop-filter: var(--glass-backdrop);
 }
 
 #loading.hidden {
@@ -304,7 +303,6 @@ dialog.modal {
 
 dialog.modal::backdrop {
     background: rgba(0, 0, 0, 0.7);
-    backdrop-filter: var(--glass-backdrop);
 }
 
 /* Legacy div modal support (for backward compatibility) */
@@ -331,7 +329,6 @@ div.modal.hidden {
     right: 0;
     bottom: 0;
     background: rgba(0, 0, 0, 0.7);
-    backdrop-filter: var(--glass-backdrop);
 }
 
 .modal-content {
@@ -478,8 +475,6 @@ div.modal.hidden {
     line-height: 1.4;
     max-width: 420px;
     text-align: center;
-    backdrop-filter: var(--glass-backdrop);
-    -webkit-backdrop-filter: var(--glass-backdrop);
     box-shadow: var(--shadow-lg);
     opacity: 0;
     transform: translateY(-12px);

--- a/src/css/monitor.css
+++ b/src/css/monitor.css
@@ -396,9 +396,7 @@ body.full-page-mode .full-page-toolbar-wrapper {
     align-items: center;
     gap: 4px;
     padding: 6px 12px;
-    background: rgba(10, 10, 11, 0.85);
-    backdrop-filter: var(--glass-backdrop);
-    -webkit-backdrop-filter: var(--glass-backdrop);
+    background: rgb(10, 10, 11);
     border: 1px solid rgba(255, 255, 255, 0.08);
     border-top: none;
     border-radius: 0 0 10px 10px;

--- a/src/css/window-switcher.css
+++ b/src/css/window-switcher.css
@@ -10,7 +10,6 @@
     right: 0;
     bottom: 0;
     background: rgba(0, 0, 0, 0.5);
-    backdrop-filter: var(--glass-backdrop);
     z-index: 1950;
     display: flex;
     align-items: center;

--- a/src/js/debug/memory-browser-window.js
+++ b/src/js/debug/memory-browser-window.js
@@ -324,12 +324,20 @@ export class MemoryBrowserWindow extends BaseWindow {
     if (!this.contentDiv) return;
     const container = this.contentDiv.parentElement;
     if (!container) return;
-    const height = container.clientHeight;
-    if (height > 0) {
-      // Each row is ~17px (11px font * 1.4 line-height + 2px padding)
-      const rowHeight = 17;
-      this.visibleRows = Math.max(1, Math.floor(height / rowHeight));
-    }
+
+    // Each row is ~17px (11px font * 1.4 line-height + 2px padding)
+    const rowHeight = 17;
+    const rows = Math.floor(container.clientHeight / rowHeight);
+
+    // Ignore a measurement that cannot fit a single row. The container is laid
+    // out to a definite height, so this only happens before layout has run or
+    // while the window is collapsed — and trusting it is dangerous: the row
+    // count drives how much gets rendered, so a bogus small value can become
+    // self-fulfilling and stick. Keeping the previous value means the view
+    // simply re-measures on the next tick.
+    if (rows < 1) return;
+
+    this.visibleRows = rows;
   }
 
   async update(wasmModule) {

--- a/src/js/display/display-settings-window.js
+++ b/src/js/display/display-settings-window.js
@@ -53,9 +53,6 @@ export class DisplaySettingsWindow extends BaseWindow {
       burnIn: 0,
       overscan: 0,
       sharpPixels: false,
-      // Opaque window panels instead of frosted glass. Null means "follow the
-      // OS preference"; true/false is an explicit user override.
-      reduceTransparency: null,
       // Color bleed (vertical inter-scanline blending)
       colorBleed: 0,
       // NTSC fringing (shader-based)
@@ -175,13 +172,6 @@ export class DisplaySettingsWindow extends BaseWindow {
             <span class="toggle-slider"></span>
           </label>
         </div>
-        <div class="setting-row toggle-row">
-          <label title="Make window panels opaque instead of frosted. Frosted panels must be re-blurred over the emulator screen every frame, which is expensive with several windows open.">Reduce Transparency</label>
-          <label class="toggle">
-            <input type="checkbox" id="ds-reduceTransparency" ${this._reduceTransparencyActive() ? "checked" : ""}>
-            <span class="toggle-slider"></span>
-          </label>
-        </div>
       </div>`;
 
     // NTSC Effects sliders (shader-based)
@@ -270,18 +260,6 @@ export class DisplaySettingsWindow extends BaseWindow {
       });
     }
 
-    // Reduce transparency toggle
-    const transparencyToggle = this.contentElement.querySelector(
-      "#ds-reduceTransparency",
-    );
-    if (transparencyToggle) {
-      transparencyToggle.addEventListener("change", (e) => {
-        this.settings.reduceTransparency = e.target.checked;
-        this.applyReduceTransparency();
-        this.saveSettings();
-      });
-    }
-
     // Color Bleed slider (shader-based)
     const colorBleedInput =
       this.contentElement.querySelector("#ds-colorBleed");
@@ -324,10 +302,6 @@ export class DisplaySettingsWindow extends BaseWindow {
   create() {
     super.create();
     this.loadSettings();
-    // Transparency affects the whole chrome, not just the emulator screen, so
-    // apply it here rather than waiting for applyAllSettings() — the user may
-    // never open this window, and the frosted panels are on screen from boot.
-    this.applyReduceTransparency();
     this.setupContentEventListeners();
     // applyAllSettings() is called by main.js after initialization
   }
@@ -405,15 +379,6 @@ export class DisplaySettingsWindow extends BaseWindow {
       this.renderer.setNearestFilter(this.settings.sharpPixels);
     }
 
-    // Apply reduced transparency
-    const transparencyToggle = this.contentElement.querySelector(
-      "#ds-reduceTransparency",
-    );
-    if (transparencyToggle) {
-      transparencyToggle.checked = this._reduceTransparencyActive();
-    }
-    this.applyReduceTransparency();
-
     // Apply color bleed settings (shader-based)
     {
       const input = this.contentElement.querySelector("#ds-colorBleed");
@@ -432,37 +397,6 @@ export class DisplaySettingsWindow extends BaseWindow {
     this.settings = { ...this.defaults };
     this.applyAllSettings();
     this.saveSettings();
-  }
-
-  /**
-   * Whether frosted panels are currently switched off, taking the OS
-   * preference as the default when the user has not chosen explicitly.
-   */
-  _reduceTransparencyActive() {
-    if (this.settings.reduceTransparency !== null) {
-      return this.settings.reduceTransparency;
-    }
-    return (
-      typeof matchMedia === "function" &&
-      matchMedia("(prefers-reduced-transparency: reduce)").matches
-    );
-  }
-
-  /**
-   * Publish the transparency choice to CSS.
-   *
-   * The attribute is only set when the user has made an explicit choice —
-   * leaving it absent lets the prefers-reduced-transparency media query in
-   * base.css decide, and setting it to "false" is what opts back out of that
-   * query for a user who wants the frosted look despite the OS preference.
-   */
-  applyReduceTransparency() {
-    const choice = this.settings.reduceTransparency;
-    if (choice === null || choice === undefined) {
-      delete document.documentElement.dataset.reduceTransparency;
-    } else {
-      document.documentElement.dataset.reduceTransparency = String(choice);
-    }
   }
 
   saveSettings() {


### PR DESCRIPTION
Every window, panel, menu and popout is now a plain opaque surface. All 23 `backdrop-filter` declarations are gone and the surface tokens are fully opaque instead of 0.6–0.92 alpha.

This also **removes the Reduce Transparency setting** I added in #45. With transparency gone unconditionally that toggle controls nothing, so keeping it would leave a dead switch in Display Settings.

## Changes

- **`base.css`** — `--glass-bg`, `--glass-bg-solid` and `--glass-bg-header` are opaque in both themes. The `--glass-backdrop` tokens and the `[data-reduce-transparency]` / `prefers-reduced-transparency` blocks are deleted. Token *names* are kept because ~90 rules reference them.
- **All ten stylesheets** that had `backdrop-filter` / `-webkit-backdrop-filter` — declarations removed.
- **`monitor.css`, `fullscreen-popouts.css`** — the full-page toolbar, popout tab, slide-out panel and its dropdown hardcoded translucent backgrounds rather than using the tokens, so they're made opaque directly. The popout tab's hover shade is lightened to `rgb(26,26,28)` since alpha can no longer convey the hover state; this preserves the original tab/panel tonal relationship.
- **`display-settings-window.js`** — drops the `reduceTransparency` setting, its markup, change handler, apply calls and both helper methods.

## Deliberately left translucent

- **Modal and window-switcher scrims** (`rgba(0,0,0,0.5–0.7)`). These dim the app *behind* a dialog rather than being window backgrounds — making them opaque would black out the screen. Their blur is gone.
- **Tinted inner chips** such as the CPU flag indicators and soft switch badges, which layer accent colour over an already-opaque window. That's how the design conveys state, not window transparency.

Say the word if you want either of those flattened too.

## Performance side effect

Beyond appearance, this removes real GPU cost. The panels sit over a canvas that repaints 60 times a second, so the compositor had to re-blur the full area of every open window on every frame — regardless of whether that window's content changed. Opaque rects cost nothing to composite. This is the unconditional version of what #45 made available as an opt-in.

## Verification

Driven in a browser, both themes, with three debug windows open over a running emulator:

| Check | Dark | Light |
|---|---|---|
| Elements reporting a backdrop filter | **0** | **0** |
| Window surface | `rgb(13, 17, 23)` | `rgb(255, 255, 255)` |
| Window header | `rgb(33, 38, 45)` | `rgb(246, 248, 250)` |
| Overlapping windows occlude fully | yes | yes |

Display Settings still renders all 25 setting rows, the Sharp Pixels toggle works, the removed toggle is absent, no stale `data-reduce-transparency` attribute is set, and Reset to Defaults runs without error. No console errors. `npm run check` passes (282 exports, 91 tests) and `vite build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
