### PR TITLE
Fix BASIC running state after save-state restore; drop dead File menu footer

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -124,10 +124,6 @@
                             >
                                 <span>Save States...</span>
                             </button>
-                            <div
-                                id="state-last-saved"
-                                class="header-menu-footer"
-                            ></div>
                             <div class="header-menu-separator"></div>
                             <button
                                 class="header-menu-item menu-item-danger"

--- a/src/core/emulator/emulator_state.cpp
+++ b/src/core/emulator/emulator_state.cpp
@@ -575,6 +575,14 @@ bool Emulator::importState(const uint8_t *data, size_t size) {
   breakpointHit_ = false;
   paused_ = false;
 
+  // basicProgramRunning_ is inferred from ROM entry points ($D912 RUN, $D43C
+  // RESTART), so reset() above cleared it and a state captured mid-RUN would
+  // never see $D912 again — the flag would stay false for the rest of the
+  // program. Rederive it from the restored RAM using the ROM's own direct-mode
+  // test: CURLIN+1 ($76) == $FF means we are at the ] prompt, anything else
+  // means a program is executing.
+  basicProgramRunning_ = mmu_->readRAM(0x76, false) != 0xFF;
+
   return true;
 }
 

--- a/src/css/controls.css
+++ b/src/css/controls.css
@@ -396,20 +396,6 @@
     margin: 4px 8px;
 }
 
-/* Menu footer text (e.g., "Last saved: 2 min ago") */
-.header-menu-footer {
-    padding: 6px 12px;
-    font-size: 0.6875rem;
-    color: var(--text-muted);
-    text-align: center;
-    border-top: 1px solid var(--glass-border);
-    font-style: italic;
-}
-
-.header-menu-footer:empty {
-    display: none;
-}
-
 /* State status badge (in menu) */
 .state-status {
     font-size: 0.625rem;

--- a/src/js/state/state-manager.js
+++ b/src/js/state/state-manager.js
@@ -14,7 +14,6 @@ import {
   saveStateToStorage,
   loadStateFromStorage,
   hasSavedState,
-  getSavedStateTimestamp,
   saveStateToSlot,
   loadStateFromSlot,
 } from "./state-persistence.js";
@@ -135,54 +134,12 @@ export class StateManager {
       autosaveToggle.checked = this.autoSaveEnabled;
     }
 
-    // Update last saved time when system menu opens
-    const systemMenuContainer = document.getElementById("file-menu-container");
-    if (systemMenuContainer) {
-      const observer = new MutationObserver(() => {
-        if (systemMenuContainer.classList.contains("open")) {
-          this.updateLastSavedTime();
-        }
-      });
-      observer.observe(systemMenuContainer, { attributes: true, attributeFilter: ["class"] });
-    }
-
     // Auto-save toggle
     if (autosaveToggle) {
       autosaveToggle.addEventListener("change", () => {
         this.autoSaveEnabled = autosaveToggle.checked;
         localStorage.setItem("a2e-autosave-state", this.autoSaveEnabled);
       });
-    }
-  }
-
-  /**
-   * Update the "last saved" time display
-   */
-  async updateLastSavedTime() {
-    const lastSavedEl = document.getElementById("state-last-saved");
-    if (!lastSavedEl) return;
-
-    const timestamp = await getSavedStateTimestamp();
-    if (timestamp) {
-      const date = new Date(timestamp);
-      const now = new Date();
-      const diffMs = now - date;
-      const diffMins = Math.floor(diffMs / 60000);
-      const diffHours = Math.floor(diffMs / 3600000);
-
-      let timeStr;
-      if (diffMins < 1) {
-        timeStr = "just now";
-      } else if (diffMins < 60) {
-        timeStr = `${diffMins} minute${diffMins === 1 ? "" : "s"} ago`;
-      } else if (diffHours < 24) {
-        timeStr = `${diffHours} hour${diffHours === 1 ? "" : "s"} ago`;
-      } else {
-        timeStr = date.toLocaleDateString();
-      }
-      lastSavedEl.textContent = `Last saved: ${timeStr}`;
-    } else {
-      lastSavedEl.textContent = "No saved state";
     }
   }
 

--- a/tests/integration/test_emulator_state.cpp
+++ b/tests/integration/test_emulator_state.cpp
@@ -161,3 +161,44 @@ TEST_CASE("Emulator importState rejects empty data", "[emulator][state]") {
     bool result = emu.importState(nullptr, 0);
     REQUIRE_FALSE(result);
 }
+
+// ---------------------------------------------------------------------------
+// Round-trip: BASIC running state
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Emulator state round-trip restores BASIC running flag", "[emulator][state][basic]") {
+    Emulator emu;
+    emu.init();
+
+    // basicProgramRunning_ is normally set by the $D912 ROM hook, which a
+    // restored mid-RUN state will never cross again. Stand in for that by
+    // setting CURLIN ($75/$76) to a real line number, as the ROM does while a
+    // program executes.
+    emu.writeMemory(0x0075, 0x0A);  // CURLIN lo = line 10
+    emu.writeMemory(0x0076, 0x00);  // CURLIN hi != $FF -> not direct mode
+
+    size_t size = 0;
+    const uint8_t* data = emu.exportState(&size);
+    std::vector<uint8_t> stateCopy(data, data + size);
+
+    emu.reset();
+    REQUIRE_FALSE(emu.isBasicProgramRunning());
+
+    REQUIRE(emu.importState(stateCopy.data(), stateCopy.size()));
+    REQUIRE(emu.isBasicProgramRunning());
+}
+
+TEST_CASE("Emulator state round-trip leaves BASIC idle at the prompt", "[emulator][state][basic]") {
+    Emulator emu;
+    emu.init();
+
+    // CURLIN+1 == $FF is the ROM's direct-mode marker: sitting at the ] prompt.
+    emu.writeMemory(0x0076, 0xFF);
+
+    size_t size = 0;
+    const uint8_t* data = emu.exportState(&size);
+    std::vector<uint8_t> stateCopy(data, data + size);
+
+    REQUIRE(emu.importState(stateCopy.data(), stateCopy.size()));
+    REQUIRE_FALSE(emu.isBasicProgramRunning());
+}


### PR DESCRIPTION
## Summary

Two small fixes.

**BASIC running flag lost on state restore.** `basicProgramRunning_` is inferred by watching the CPU cross Applesoft's ROM entry points (`$D912` RUN, `$D43C` RESTART). `importState()` calls `reset()`, which clears the flag, and a state captured mid-RUN resumes *inside* the program so `$D912` is never crossed again — the flag stayed false for the rest of the run. The BASIC Program Viewer polls `_isBasicProgramRunning()` for both its status chip and `state.running` in `basic-program-parser.js`, so a restored running program showed as idle with no current-line trace and no variable auto-refresh.

Fixed by rederiving the flag from the restored CURLIN+1 (`$76`) using the ROM's own direct-mode test (`$FF` = at the `]` prompt). No state-format version bump, so existing save states restore correctly too.

**Dead File menu footer.** The Save States group in the File menu ended in a `#state-last-saved` element that never showed anything useful — the Save States window already has an autosave row with its own timestamp. Removed the element, the `MutationObserver` and `updateLastSavedTime()` that fed it, and the now-unused `.header-menu-footer` CSS.

## Testing

- Two new cases in `tests/integration/test_emulator_state.cpp`: a mid-run state comes back running; a state saved at the prompt stays idle.
- `ctest` — 40/40 passing.
- `npm run check` — 91 JS tests plus all three consistency guards passing.
- Confirmed working in the browser by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)