### PR TITLE
Let arrow keys reach the emulator in Joystick Cursor Keys mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -362,7 +362,7 @@ Built-in debug windows accessible via Debug menu:
 | F11              | Step Into                |
 | Shift+F11        | Step Out                 |
 
-The Joystick window has a **Cursor Keys** toggle that remaps the arrow keys to joystick input (full deflection 0/255 per axis). When enabled, a "CURSOR KEYS" chip appears in the Monitor title bar. The setting persists via localStorage.
+The Joystick window has a **Cursor Keys** toggle that also drives the joystick from the arrow keys (full deflection 0/255 per axis). The arrows keep reaching the emulator's keyboard as normal, so ProDOS selectors, catalog menus and BASIC line editing still work while the toggle is on. When enabled, a "CURSOR KEYS" chip appears in the Monitor title bar. The setting persists via localStorage.
 
 ## Agent / MCP Integration
 

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Cards are configured via **View > Expansion Slots**.
 
 ### Joystick & Game Controllers
 
-A floating joystick window provides visual paddle/joystick controls that map to the Apple II game ports ($C064-$C067). Physical game controllers are supported via the Gamepad API — the left stick maps to paddle values and buttons A/B map to Apple II buttons 0/1, with a configurable deadzone. A **Cursor Keys** toggle remaps the arrow keys to joystick input, with an indicator chip in the Monitor title bar when active.
+A floating joystick window provides visual paddle/joystick controls that map to the Apple II game ports ($C064-$C067). Physical game controllers are supported via the Gamepad API — the left stick maps to paddle values and buttons A/B map to Apple II buttons 0/1, with a configurable deadzone. A **Cursor Keys** toggle makes the arrow keys drive the joystick as well as the keyboard — they still reach the emulator, so arrow-key navigation in ProDOS and BASIC keeps working — with an indicator chip in the Monitor title bar when active.
 
 ## Architecture
 

--- a/src/js/help/documentation-window.js
+++ b/src/js/help/documentation-window.js
@@ -373,7 +373,7 @@ export class DocumentationWindow extends BaseWindow {
         <p>Open <strong>View &gt; Joystick / Paddles</strong> for an on-screen controller with a draggable pad, PDL0/PDL1 gauges, and button 0/1 (Open/Closed Apple) indicators.</p>
         <ul>
           <li><strong>Physical controllers:</strong> Enable the <strong>Gamepad</strong> toggle to use a connected game controller via the browser Gamepad API. The left stick maps to the paddles and the A/B buttons to Apple buttons 0/1, with an adjustable deadzone.</li>
-          <li><strong>Cursor keys as joystick:</strong> A <strong>JOY</strong> toggle in the screen window's title bar remaps the arrow keys to full-deflection joystick input for games that expect a joystick. The label highlights green while active, and the setting is remembered between sessions.</li>
+          <li><strong>Cursor keys as joystick:</strong> A <strong>JOY</strong> toggle in the screen window's title bar makes the arrow keys drive full-deflection joystick input for games that expect a joystick. The arrows still reach the emulator as ordinary keys, so ProDOS and BASIC navigation keeps working while it is on. The label highlights green while active, and the setting is remembered between sessions.</li>
         </ul>
       </section>
 

--- a/src/js/input/input-handler.js
+++ b/src/js/input/input-handler.js
@@ -153,10 +153,12 @@ export class InputHandler {
       event.preventDefault();
     }
 
-    // Check if cursor keys should act as joystick
-    if (this.joystickWindow && this.joystickWindow.handleCursorKey(keyCode, true)) {
-      event.preventDefault();
-      return;
+    // Cursor Keys mode makes the arrows drive the joystick *as well as* the
+    // keyboard — it must not swallow them. ProDOS selectors, catalog menus and
+    // BASIC line editing all navigate with the arrows, and consuming them here
+    // left those unusable whenever the toggle was on.
+    if (this.joystickWindow) {
+      this.joystickWindow.handleCursorKey(keyCode, true);
     }
 
     // Send raw keycode to WASM - C++ handles the translation
@@ -179,9 +181,10 @@ export class InputHandler {
       return;
     }
 
-    // Check if cursor keys should act as joystick
-    if (this.joystickWindow && this.joystickWindow.handleCursorKey(keyCode, false)) {
-      return;
+    // Release the joystick axis, then let the key reach the emulator as normal
+    // (see the matching note in handleKeyDown).
+    if (this.joystickWindow) {
+      this.joystickWindow.handleCursorKey(keyCode, false);
     }
 
     // Send raw keycode to WASM


### PR DESCRIPTION
Fixes #43.

## Summary

`handleKeyDown` / `handleKeyUp` returned early whenever `handleCursorKey()` claimed an arrow key, so with the Joystick window's **Cursor Keys** toggle on the arrows never reached `_handleRawKeyDown`. Anything that navigates with them — ProDOS file selectors (Bitsy Bye), ProDOS catalog menus, BASIC line editing — was unusable while the toggle was on.

`handleCursorKey()` is now called for its side effect (updating the paddle axis) and the key falls through to the emulator. The toggle controls whether the arrows *also* drive the joystick, not whether they still work as keys.

The `event.preventDefault()` in the removed branch was redundant — `shouldPreventDefault()` already covers keycodes 37–40 and runs earlier in the same function — so scroll suppression is unchanged.

Reported by @anomixer, matching the fix Chris made in ct6502/apple2ts#272.

## Testing

Verified in headless Chrome at the BASIC prompt with `_handleRawKeyDown` spied on:

| | joystick `knobX` | keycode reaching emulator |
|---|---|---|
| Cursor Keys **on**, right-arrow down | `0.5` → `1` | ✅ 39 |
| ...right-arrow up | back to `0.5` | — |
| Cursor Keys **off**, right-arrow down | unchanged `0.5` | ✅ 39 |

No console errors. `npm run check` passes (91 tests plus all three consistency guards).

No automated test: `input-handler.js` is DOM-coupled (canvas focus, `KeyboardEvent`) and the `tests/js` suite deliberately runs in plain node per CLAUDE.md, so adding jsdom for this seemed the wrong trade.

Docs updated in the three places that described the old "remaps the arrow keys" behaviour: `CLAUDE.md`, `README.md`, and the in-app help.

🤖 Generated with [Claude Code](https://claude.com/claude-code)