### PR TITLE
Stop handling every keyboard event twice

### DIFF
--- a/src/js/input/input-handler.js
+++ b/src/js/input/input-handler.js
@@ -75,28 +75,25 @@ export class InputHandler {
       setTimeout(() => this.canvas.focus(), 100);
     }
 
-    // Keyboard event listeners - attach to canvas for better focus control
-    this.canvas.addEventListener("keydown", (e) => this.handleKeyDown(e));
-    this.canvas.addEventListener("keyup", (e) => this.handleKeyUp(e));
+    // A single document-level pair of listeners, deliberately. Listening on the
+    // canvas as well would double every keystroke: a key press targets the
+    // focused canvas, runs the canvas listener in the target phase, then bubbles
+    // to document where the guard below is true by definition — so every key
+    // reached the emulator twice, and any per-key side effect (the Cursor Keys
+    // joystick update, for one) ran twice with it.
+    //
+    // Document is the one that has to stay: it also covers the case where focus
+    // has drifted to <body>, which the canvas listener never sees.
+    const focusIsOurs = () =>
+      document.activeElement === this.canvas ||
+      document.activeElement === document.body;
 
-    // Also listen on document but only process if canvas has focus or no other element does
     document.addEventListener("keydown", (e) => {
-      // Only handle if canvas has focus or the active element is body
-      if (
-        document.activeElement === this.canvas ||
-        document.activeElement === document.body
-      ) {
-        this.handleKeyDown(e);
-      }
+      if (focusIsOurs()) this.handleKeyDown(e);
     });
 
     document.addEventListener("keyup", (e) => {
-      if (
-        document.activeElement === this.canvas ||
-        document.activeElement === document.body
-      ) {
-        this.handleKeyUp(e);
-      }
+      if (focusIsOurs()) this.handleKeyUp(e);
     });
 
     // A key held while switching away never delivers its keyup, which would


### PR DESCRIPTION
## Summary

Follow-up from reviewing #50. `InputHandler.init()` registered `keydown`/`keyup` on **both** the canvas and `document`. A key press targets the focused canvas, runs the canvas listener in the target phase, then bubbles to `document` — where the "is focus ours" guard (`activeElement === canvas`) is true by definition. So `handleKeyDown`/`handleKeyUp` ran twice for every keystroke.

Measured in a browser with real key events (`Input.dispatchKeyEvent`, not synthetic `dispatchEvent`), typing `A` then Right-Arrow with Cursor Keys on:

**Before**
```
down:   [65, 65, 39, 39]
up:     [65, 65, 39, 39]
cursor: [65v, 65v, 65^, 65^, 39v, 39v, 39^, 39^]
```

**After**
```
down:   [65, 39]
up:     [65, 39]
cursor: [65v, 65^, 39v, 39^]
```

That was two `_handleRawKeyDown` RPCs per keystroke, plus every per-key side effect running twice with them — including the Cursor Keys joystick update from #50. The emulator's key latch made the duplicate harmless in output terms, which is presumably why it went unnoticed.

## Why the canvas pair is the one to drop

The `document` pair is strictly the more general of the two: it fires for the canvas-focused case *and* for focus drifting to `<body>`, which the canvas listener never sees (the event targets `body`, not the canvas). The canvas listener has no case of its own.

`text-selection.js` registers on `document` in the **capture** phase and calls `stopPropagation()` for Ctrl+C and Escape. Capture runs before the target phase, so that already suppressed both listeners — no behaviour change there.

## Testing

- Real browser key events before/after, as above
- Typed at the `]` prompt with focus on the canvas **and** with focus on `<body>` — both still reach the emulator, no console errors
- `npm run check` passes (91 tests plus all three consistency guards)

🤖 Generated with [Claude Code](https://claude.com/claude-code)