### PR TITLE
Bust caches for shader files on every release

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,8 +1,16 @@
 // Service Worker for Apple //e Emulator
 // Enables offline functionality by caching app assets
 
-// IMPORTANT: Bump this version when WASM or core JS files change
-const CACHE_VERSION = 3.8;
+// Replaced at build time with the app version from src/js/config/version.js by
+// the stamp-service-worker-version plugin in vite.config.js — do not rely on
+// the literal below in production, and do not hand-bump it.
+//
+// It has to change whenever a stable-named precached asset changes, because
+// those are served cache-first and their URLs never change. It used to be a
+// hand-maintained number, which meant 1.1.12 shipped a rewritten crt.glsl that
+// returning browsers carried on ignoring. Tying it to the release version makes
+// that automatic. The value here is only what the dev server sees.
+const CACHE_VERSION = "dev";
 const CACHE_NAME = `a2e-cache-v${CACHE_VERSION}`;
 
 // Files that should always be fetched fresh (network-first).
@@ -37,7 +45,9 @@ const PRECACHE_ASSETS = [
   "/audio-worklet.js",
   "/emulator-worker.js",
   // Fetched at runtime by WebGLRenderer.init(), which throws without them —
-  // so an offline launch failed before drawing anything.
+  // so an offline launch failed before drawing anything. Cached under their
+  // bare paths; loadShader() asks for them with a ?v= cache buster, which the
+  // lookup below deliberately ignores.
   "/shaders/vertex.glsl",
   "/shaders/crt.glsl",
   "/shaders/burnin.glsl",
@@ -185,9 +195,18 @@ self.addEventListener("fetch", (event) => {
     return;
   }
 
-  // Cache-first for other assets
+  // Cache-first for other assets.
+  //
+  // Shaders are requested with a ?v=<app version> cache buster but precached
+  // under their bare path, so their lookup has to ignore the query string.
+  // That cannot serve a stale shader: the cache name carries the app version
+  // too, so a release starts from an empty cache.
+  const matchOptions = url.pathname.endsWith(".glsl")
+    ? { ignoreSearch: true }
+    : undefined;
+
   event.respondWith(
-    caches.match(event.request).then((cachedResponse) => {
+    caches.match(event.request, matchOptions).then((cachedResponse) => {
       if (cachedResponse) {
         // Return cached response
         return cachedResponse;

--- a/src/js/display/webgl-renderer.js
+++ b/src/js/display/webgl-renderer.js
@@ -5,6 +5,8 @@
  *  Mike Daley <michael_daley@icloud.com>
  */
 
+import { VERSION } from "../config/version.js";
+
 export class WebGLRenderer {
   constructor(canvas) {
     this.canvas = canvas;
@@ -743,8 +745,20 @@ export class WebGLRenderer {
     this._pendingHeight = Math.floor(height * dpr);
   }
 
+  /**
+   * Fetch a shader source file.
+   *
+   * The ?v= is not decoration. Unlike the JS and CSS bundles, shader files keep
+   * the same URL from one build to the next, so a browser that has one in its
+   * HTTP cache will happily keep using it after a deploy — which is exactly how
+   * 1.1.12 shipped a rewritten crt.glsl that nobody saw. Stamping the app
+   * version into the URL makes every release a fresh resource. The service
+   * worker precaches the same versioned URLs (see PRECACHE_ASSETS in sw.js), so
+   * offline launches still find them.
+   */
   async loadShader(path) {
-    const response = await fetch(path);
+    const url = `${path}?v=${VERSION}`;
+    const response = await fetch(url);
     if (!response.ok) {
       throw new Error(`Failed to load shader: ${path}`);
     }

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,41 @@
 import { defineConfig } from "vite";
 import { resolve } from "path";
-import { copyFileSync, mkdirSync } from "fs";
+import { copyFileSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { serialProxyPlugin } from "./plugins/serial-proxy-plugin.js";
+
+// Stamp the app version into the service worker's cache name.
+//
+// The service worker precaches stable-named assets — the shaders, the audio
+// worklet, the emulator worker — cache-first, keyed on CACHE_VERSION. Those
+// names never change between builds, so a returning browser keeps serving the
+// old copy until the cache name changes. The file asked you to remember to bump
+// it by hand, and 1.1.12 shipped a rewritten crt.glsl that nobody could see
+// because nobody did. Deriving it from the version that is bumped every release
+// removes the chance to forget.
+const stampServiceWorkerVersion = () => ({
+  name: "stamp-service-worker-version",
+  writeBundle() {
+    const versionSrc = readFileSync(
+      resolve(__dirname, "src/js/config/version.js"),
+      "utf8",
+    );
+    const version = versionSrc.match(/VERSION\s*=\s*"([^"]+)"/)?.[1];
+    if (!version) {
+      throw new Error("stamp-service-worker-version: no VERSION in version.js");
+    }
+
+    const swPath = resolve(__dirname, "dist/sw.js");
+    const sw = readFileSync(swPath, "utf8");
+    const stamped = sw.replace(
+      /const CACHE_VERSION = [^;]+;/,
+      `const CACHE_VERSION = "${version}";`,
+    );
+    if (stamped === sw) {
+      throw new Error("stamp-service-worker-version: CACHE_VERSION not found");
+    }
+    writeFileSync(swPath, stamped);
+  },
+});
 
 // Plugin to copy audio worklet and emulator worker files (can't be bundled)
 const copyWorkerFiles = () => ({
@@ -94,5 +128,9 @@ export default defineConfig({
     exclude: ["a2e.js"],
   },
 
-  plugins: [serialProxyPlugin(), copyWorkerFiles()],
+  plugins: [
+    serialProxyPlugin(),
+    copyWorkerFiles(),
+    stampServiceWorkerVersion(),
+  ],
 });


### PR DESCRIPTION
## Summary

1.1.12 shipped a rewritten `crt.glsl` that production kept ignoring. The deploy was fine — the rsync did copy the new file. The problem is that **shader files keep the same URL from one build to the next**, unlike the JS and CSS bundles which carry content hashes. A browser that already had `/shaders/crt.glsl` in its HTTP cache carried on using it.

Two independent paths, both fixed:

**Ordinary browser tabs — HTTP cache.** `loadShader()` now requests `shaders/<name>.glsl?v=<app version>`, so every release is a fresh resource regardless of the cache headers the server sends.

**Installed PWA — service worker cache.** `sw.js` precaches the shaders cache-first under a cache name keyed on `CACHE_VERSION`, a hand-maintained constant whose own comment said *"IMPORTANT: Bump this version when WASM or core JS files change"* — and which was last touched at 3.8. It is now stamped from `src/js/config/version.js` at build time by a small Vite plugin, so the cache turns over on every release and the file no longer depends on anyone remembering. (Note the service worker only registers when running as an installed PWA, `main.js:833`, so this path affects a subset of users — the HTTP fix above is the one that matters for most.)

Shader lookups in the SW now match with `ignoreSearch: true`, so the bare precached path still answers the versioned request. That cannot serve a stale shader, because the cache name carries the app version too — a release starts from an empty cache.

## Testing

Against a production build served by `vite preview`:

```
shader requests: [.../vertex.glsl?v=1.1.12, .../crt.glsl?v=1.1.12,
                  .../burnin.glsl?v=1.1.12, .../edge.glsl?v=1.1.12]
program:         {linked: true, glError: 0, noSignal: 1}
served crt.glsl contains hash13: true
```

`npm run check` passes (91 tests plus all three guards). The build plugin throws rather than silently no-opping if `VERSION` or the `CACHE_VERSION` line ever moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)