### PR TITLE
CRT accessibility fixes, no-signal screen, beam bloom, shadow mask, and monitor presets

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -280,6 +280,13 @@
                             <button class="header-menu-item" id="btn-joystick">
                                 <span>Joystick / Paddles</span>
                             </button>
+                            <button
+                                class="header-menu-item"
+                                id="btn-cursor-keys-joystick"
+                            >
+                                <span>Cursor Keys as Joystick</span>
+                                <span class="menu-check-icon"></span>
+                            </button>
                             <button class="header-menu-item" id="btn-slots">
                                 <span>Expansion Slots</span>
                             </button>

--- a/public/shaders/crt.glsl
+++ b/public/shaders/crt.glsl
@@ -32,7 +32,6 @@ uniform float u_glowingLine;
 uniform float u_ambientLight;
 uniform float u_burnIn;
 uniform float u_overscan;
-uniform float u_noSignal;
 
 // NTSC fringing effect
 uniform float u_ntscFringing;
@@ -78,11 +77,11 @@ float hash12(vec2 p) {
     return fract((p3.x + p3.y) * p3.z);
 }
 
-// 3D -> 1D hash. The static uses this with the frame counter as the third
+// 3D -> 1D hash. The grain effect uses this with the frame counter as the third
 // component so every frame is an independent noise field. Feeding the frame in
 // as an offset added to the 2D coordinate instead (the old approach) only
 // translates one fixed field, which reads as rows of grain sliding across the
-// screen rather than as snow.
+// screen rather than as noise.
 float hash13(vec3 p3) {
     p3 = fract(p3 * 0.1031);
     p3 += dot(p3, p3.zyx + 31.32);
@@ -195,68 +194,6 @@ float staticNoise(vec2 uv, float time) {
     float vignette = 1.0 - dist * 0.5;
 
     return (noise - 0.5) * u_staticNoise * vignette;
-}
-
-// ============================================
-// No signal TV static (full screen)
-// ============================================
-
-vec3 noSignalStatic(vec2 uv, float time) {
-    // Grain cell. Roughly one source texel wide and one tall — fine enough that
-    // no repeating structure is legible, which is the whole point of snow.
-    vec2 grain = floor(uv * u_textureSize);
-
-    // Wrapped frame counter, fed to the hash as a third dimension so each frame
-    // is an independent field rather than the previous one slid sideways.
-    float frame = mod(floor(time * 50.0), 1024.0);
-
-    // Three horizontally adjacent taps. A real tuner's video path is band
-    // limited horizontally, so snow grains come out slightly wider than they
-    // are tall; this is the only horizontal correlation the effect should have,
-    // and it is sub-grain rather than the row-wide banding it replaces.
-    float n0 = hash13(vec3(grain, frame));
-    float n1 = hash13(vec3(grain - vec2(1.0, 0.0), frame));
-    float n2 = hash13(vec3(grain + vec2(1.0, 0.0), frame));
-    float noise = n0 * 0.6 + (n1 + n2) * 0.2;
-
-    // A flat uniform random reads as grey mush. Expanding around the midpoint
-    // separates the hot specks from the dark gaps the way real snow does.
-    noise = clamp((noise - 0.5) * 1.7 + 0.5, 0.0, 1.0);
-    noise = noise * noise * (3.0 - 2.0 * noise);
-
-    // Faint chroma speckle — analog snow on a colour set is never pure grey.
-    vec3 chroma = vec3(
-        hash13(vec3(grain, frame + 137.0)),
-        hash13(vec3(grain, frame + 271.0)),
-        hash13(vec3(grain, frame + 419.0))
-    ) - 0.5;
-
-    // Inverted polarity: a white field peppered with black grains rather than a
-    // dark field with bright specks.
-    float lum = 1.0 - noise;
-
-    // Bias towards white so the black grains stay a minority speckle instead of
-    // taking half the screen.
-    lum = pow(lum, 0.6);
-
-    // Occasional interference bar, drifting rather than teleporting so it reads
-    // as a rolling fault in the signal instead of a flashing row. Pulls towards
-    // black, matching the polarity of the grains.
-    float burst = hash13(vec3(0.0, 0.0, floor(time * 1.5)));
-    if (burst > 0.90) {
-        float barY = fract(hash13(vec3(1.0, 0.0, floor(time * 1.5))) + time * 0.35);
-        float barDist = abs(uv.y - barY);
-        float bar = 1.0 - smoothstep(0.0, 0.015, barDist);
-        lum = mix(lum, lum * 0.4, bar);
-    }
-
-    // Slight brightness variation over time
-    lum *= 0.9 + hash13(vec3(2.0, 0.0, floor(time * 12.0))) * 0.2;
-
-    lum = clamp(lum, 0.0, 1.0);
-
-    // Chroma rides on the dark grains, where a real set shows it most.
-    return vec3(lum) + chroma * 0.1 * (1.0 - lum);
 }
 
 // ============================================
@@ -776,29 +713,6 @@ void main() {
 
     // Check if we're in the margin area (outside content but inside screen)
     bool inMargin = contentUV.x < 0.0 || contentUV.x > 1.0 || contentUV.y < 0.0 || contentUV.y > 1.0;
-
-    // No signal mode - show TV static instead of emulator content
-    if (u_noSignal > 0.5) {
-        vec3 staticColor = noSignalStatic(curvedUV, u_time);
-
-        // Apply scanlines to static, but at half strength. At full strength the
-        // scanline comb is the strongest horizontal signal on screen and the
-        // snow underneath it just reads as texture on a striped field.
-        staticColor *= mix(1.0, scanlines(curvedUV), 0.5);
-
-        // Apply vignette
-        staticColor *= vignette(curvedUV);
-
-        // Apply edge fade for curved screens
-        if (u_curvature > 0.001) {
-            staticColor *= edgeFade(curvedUV);
-        }
-
-        float staticAlpha = cornerAlpha * edgeFactor;
-        staticColor = mix(bezel, staticColor, staticAlpha);
-        gl_FragColor = vec4(staticColor, 1.0);
-        return;
-    }
 
     // Get base color - dark bezel color for margin area, texture sample for content
     vec3 color;

--- a/public/shaders/crt.glsl
+++ b/public/shaders/crt.glsl
@@ -200,11 +200,28 @@ float staticNoise(vec2 uv, float time) {
 // Flicker effect
 // ============================================
 
+// Brightness undulation, as a set whose field rate is beating slowly against
+// the mains shows it. Two things here are deliberate and must stay that way:
+//
+// The modulation is continuous and slow. It used to be a fresh random level
+// held for 1/15s — up to fifteen discontinuous whole-screen luminance steps a
+// second, right inside the 3-30Hz band that triggers photosensitive epilepsy.
+// The fastest component below is 1.25Hz, so under a flash per second even
+// counting each half cycle, well clear of the WCAG 2.3.1 limit of three.
+//
+// The amplitude is small. Peak to peak is 6% at the top of the slider, against
+// the 10% relative luminance change that WCAG counts as a general flash. The
+// old code reached 15%. Raising either of these puts the effect back over the
+// line, and the flicker slider is on during normal use rather than only while
+// the machine is off.
 float flicker(float time) {
     if (u_flicker < 0.001) return 1.0;
 
-    float noiseVal = hash12(vec2(floor(time * 15.0), 0.0));
-    return 1.0 + (noiseVal - 0.5) * u_flicker * 0.15;
+    // Incommensurate periods (~0.78Hz and ~1.25Hz) so the beat never settles
+    // into an obvious loop.
+    float wobble = sin(time * 4.90) * 0.6 + sin(time * 7.85) * 0.4;
+
+    return 1.0 + wobble * u_flicker * 0.03;
 }
 
 // ============================================

--- a/public/shaders/crt.glsl
+++ b/public/shaders/crt.glsl
@@ -16,6 +16,9 @@ uniform float u_scanlineIntensity;
 uniform float u_scanlineWidth;
 uniform float u_beamBloom;
 uniform float u_shadowMask;
+uniform float u_pixelRatio;
+// Mask geometry: 0 = aperture grille (stripes), 1 = shadow mask (dot triad)
+uniform int u_maskType;
 uniform float u_glowIntensity;
 uniform float u_glowSpread;
 uniform float u_brightness;
@@ -298,19 +301,64 @@ float scanlines(vec2 uv, float luma) {
 // Shadow mask
 // ============================================
 
-vec3 shadowMask(vec2 uv) {
+// The mask is a physical object: a perforated sheet a few millimetres behind
+// the glass, with a pitch fixed in millimetres. Two things follow, and both
+// were wrong before.
+//
+// It does not change size. The old code took its pitch from device pixels
+// (mod(pos.x, 3.0) on a coordinate scaled by u_resolution), so on a Retina
+// display the whole triad spanned three physical pixels and was effectively
+// invisible — which is why the slider appeared to do so much less than it
+// should — and the pattern resized whenever the window moved between monitors
+// of different density. Working in CSS pixels via u_pixelRatio pins the pitch
+// to a constant apparent size wherever the page is viewed.
+//
+// It does not move with the signal. The old call passed the beam-distorted UV,
+// so jitter and horizontal sync dragged the mask around with the picture. A
+// mask is glued to the tube; the raster slides behind it. Deriving position
+// from gl_FragCoord ties it to the physical screen and nothing else.
+//
+// MASK_PITCH is one full RGB triad. Three CSS pixels puts one phosphor stripe
+// per CSS pixel, fine enough to read as texture rather than as stripes.
+const float MASK_PITCH = 3.0;
+
+vec3 shadowMask() {
     if (u_shadowMask < 0.001) return vec3(1.0);
 
-    vec2 pos = uv * u_resolution;
-    int px = int(mod(pos.x, 3.0));
+    // Position on the glass, in CSS pixels.
+    vec2 pos = gl_FragCoord.xy / max(u_pixelRatio, 0.001);
 
     vec3 mask;
-    if (px == 0) {
-        mask = vec3(1.0, 0.7, 0.7);
-    } else if (px == 1) {
-        mask = vec3(0.7, 1.0, 0.7);
+
+    if (u_maskType == 1) {
+        // Dot triad, as the Apple Monitor //e and most consumer sets used.
+        // Triads sit on a staggered lattice — every other row is offset by half
+        // a triad — which is what stops a shadow mask reading as vertical
+        // stripes the way an aperture grille does.
+        float row = floor(pos.y / MASK_PITCH);
+        float stagger = mod(row, 2.0) * 0.5;
+        float idx = mod(floor(pos.x / (MASK_PITCH / 3.0) + stagger * 1.5), 3.0);
+
+        mask = vec3(0.7);
+        if (idx < 0.5) mask.r = 1.0;
+        else if (idx < 1.5) mask.g = 1.0;
+        else mask.b = 1.0;
+
+        // Gap between mask rows. Without it the triads merge vertically into
+        // continuous stripes and the stagger buys nothing.
+        float withinRow = fract(pos.y / MASK_PITCH);
+        float gap = smoothstep(0.0, 0.25, withinRow) * smoothstep(1.0, 0.75, withinRow);
+        mask *= mix(0.8, 1.0, gap);
     } else {
-        mask = vec3(0.7, 0.7, 1.0);
+        // Aperture grille: continuous vertical phosphor stripes, no horizontal
+        // structure. A Trinitron look rather than an Apple one, but it is what
+        // this shader has always drawn, so it stays the default.
+        float idx = mod(floor(pos.x / (MASK_PITCH / 3.0)), 3.0);
+
+        mask = vec3(0.7);
+        if (idx < 0.5) mask.r = 1.0;
+        else if (idx < 1.5) mask.g = 1.0;
+        else mask.b = 1.0;
     }
 
     return mix(vec3(1.0), mask, u_shadowMask);
@@ -802,7 +850,7 @@ void main() {
     color *= scanlines(curvedUV, rgb2grey(color));
 
     // Apply shadow mask
-    color *= shadowMask(curvedUV);
+    color *= shadowMask();
 
     // Apply color adjustments (brightness, contrast, saturation)
     color = adjustColor(color);

--- a/public/shaders/crt.glsl
+++ b/public/shaders/crt.glsl
@@ -14,6 +14,7 @@ uniform float u_time;
 uniform float u_curvature;
 uniform float u_scanlineIntensity;
 uniform float u_scanlineWidth;
+uniform float u_beamBloom;
 uniform float u_shadowMask;
 uniform float u_glowIntensity;
 uniform float u_glowSpread;
@@ -256,12 +257,41 @@ vec3 applyAmbientLight(vec3 color, vec2 uv) {
 // Scanline effect
 // ============================================
 
-float scanlines(vec2 uv) {
+// The beam is a Gaussian spot, and its diameter grows with beam current. A
+// bright line is therefore physically fatter than a dark one and fills more of
+// the gap to its neighbours, which is why white text on a CRT looks bolder than
+// the same glyphs in a screenshot and why dark areas keep a crisp line
+// structure that bright areas lose. The old fixed comb — a sin() raised to a
+// constant power — could not express that: it darkened every line by the same
+// fraction no matter what was on it, which reads as stripes laid over the
+// picture rather than as a raster.
+//
+// `luma` is the luminance actually being displayed at this fragment, so the
+// width responds to the final image (bleed, fringing and selection overlay
+// included) rather than to a raw texture sample.
+float scanlines(vec2 uv, float luma) {
     if (u_scanlineIntensity < 0.001) return 1.0;
 
-    float scanline = sin(uv.y * u_textureSize.y * PI) * 0.5 + 0.5;
-    scanline = pow(scanline, u_scanlineWidth * 2.0 + 0.5);
-    return mix(1.0, scanline, u_scanlineIntensity);
+    // The framebuffer is 560x384 — the Apple's 280x192 doubled — so a scanline
+    // pitch is two texel rows. This yields 192 lines, matching the real raster.
+    float linePos = uv.y * u_textureSize.y * 0.5;
+
+    // Distance from the centre of the nearest line, in pitch units.
+    float dist = fract(linePos) - 0.5;
+
+    // Spot size. The base is the user's scanline width; brightness widens it
+    // from there. sqrt() because perceived brightness runs ahead of beam
+    // current — mid tones should already be blooming, not just peak white.
+    float sigma = mix(0.18, 0.42, u_scanlineWidth);
+    sigma *= 1.0 + sqrt(clamp(luma, 0.0, 1.0)) * u_beamBloom * 1.6;
+
+    // Gaussian profile, peak 1.0 at the line centre. Never exceeding 1.0 means
+    // a bloomed line loses less to the gaps rather than being boosted above its
+    // own colour, so the effect cannot brighten the picture beyond the source.
+    float x = dist / sigma;
+    float profile = exp(-0.5 * x * x);
+
+    return mix(1.0, profile, u_scanlineIntensity);
 }
 
 // ============================================
@@ -769,7 +799,7 @@ void main() {
     }
 
     // Apply scanlines (use curvedUV for consistent scanlines across margin)
-    color *= scanlines(curvedUV);
+    color *= scanlines(curvedUV, rgb2grey(color));
 
     // Apply shadow mask
     color *= shadowMask(curvedUV);

--- a/src/css/settings-windows.css
+++ b/src/css/settings-windows.css
@@ -342,6 +342,32 @@
     background: var(--accent-green);
 }
 
+/* Monitor preset description */
+.display-settings-content .preset-description {
+    font-family: var(--font-sans);
+    font-size: 9px;
+    line-height: 1.4;
+    color: var(--text-secondary);
+    margin-top: 5px;
+    opacity: 0.85;
+}
+
+/* Advanced disclosure */
+.display-settings-content .settings-section-title.collapsible {
+    cursor: pointer;
+    user-select: none;
+    margin-bottom: 0;
+}
+
+.display-settings-content .advanced-content .settings-section {
+    padding: 6px 0 0;
+    background: none;
+}
+
+.display-settings-content .advanced-content .settings-section:first-child {
+    padding-top: 8px;
+}
+
 /* Reset button */
 .display-settings-content .settings-actions {
     padding-top: 8px;

--- a/src/js/display/display-settings-window.js
+++ b/src/js/display/display-settings-window.js
@@ -37,6 +37,9 @@ export class DisplaySettingsWindow extends BaseWindow {
     this.defaults = {
       curvature: 0,
       scanlines: 0,
+      // Beam bloom is a property of the spot, not an effect of its own: it only
+      // shows through the scanline comb, so it ships on rather than at zero.
+      beamBloom: 60,
       shadowMask: 0,
       phosphorGlow: 0,
       vignette: 0,
@@ -77,6 +80,7 @@ export class DisplaySettingsWindow extends BaseWindow {
           { id: "curvature", label: "Screen Curvature", param: "curvature" },
           { id: "overscan", label: "Screen Border", param: "overscan" },
           { id: "scanlines", label: "Scanlines", param: "scanlineIntensity" },
+          { id: "beamBloom", label: "Beam Bloom", param: "beamBloom" },
           { id: "shadowMask", label: "Shadow Mask", param: "shadowMask" },
           {
             id: "phosphorGlow",

--- a/src/js/display/display-settings-window.js
+++ b/src/js/display/display-settings-window.js
@@ -25,6 +25,11 @@ export class DisplaySettingsWindow extends BaseWindow {
     this.wasmModule = wasmModule;
 
     // Monochrome mode options
+    this.maskTypes = [
+      { value: 0, label: "Aperture Grille" },
+      { value: 1, label: "Shadow Mask" },
+    ];
+
     this.monochromeModes = [
       { value: 0, label: "Color" },
       { value: 1, label: "Green" },
@@ -41,6 +46,8 @@ export class DisplaySettingsWindow extends BaseWindow {
       // shows through the scanline comb, so it ships on rather than at zero.
       beamBloom: 60,
       shadowMask: 0,
+      // 0 = aperture grille (stripes), 1 = shadow mask (dot triad)
+      maskType: 0,
       phosphorGlow: 0,
       vignette: 0,
       brightness: 100,
@@ -159,6 +166,17 @@ export class DisplaySettingsWindow extends BaseWindow {
       <div class="settings-section">
         <div class="settings-section-title">Rendering</div>
         <div class="setting-row">
+          <label>Mask Type</label>
+          <select id="ds-maskType" class="settings-select">
+            ${this.maskTypes
+              .map(
+                (t) =>
+                  `<option value="${t.value}" ${this.settings.maskType === t.value ? "selected" : ""}>${t.label}</option>`,
+              )
+              .join("")}
+          </select>
+        </div>
+        <div class="setting-row">
           <label>Display Mode</label>
           <select id="ds-monochromeMode" class="settings-select">
             ${this.monochromeModes
@@ -231,6 +249,17 @@ export class DisplaySettingsWindow extends BaseWindow {
       colorPicker.addEventListener("input", (e) => {
         this.settings.bezelColor = e.target.value;
         this.applyBezelColor(e.target.value);
+        this.saveSettings();
+      });
+    }
+
+    // Mask type dropdown
+    const maskSelect = this.contentElement.querySelector("#ds-maskType");
+    if (maskSelect) {
+      maskSelect.addEventListener("change", (e) => {
+        const value = parseInt(e.target.value, 10);
+        this.settings.maskType = value;
+        this.applyToRenderer("maskType", value);
         this.saveSettings();
       });
     }
@@ -360,6 +389,13 @@ export class DisplaySettingsWindow extends BaseWindow {
     const colorPicker = this.contentElement.querySelector("#ds-bezelColor");
     if (colorPicker) colorPicker.value = this.settings.bezelColor;
     this.applyBezelColor(this.settings.bezelColor);
+
+    // Apply mask type
+    const maskTypeSelect = this.contentElement.querySelector("#ds-maskType");
+    if (maskTypeSelect) {
+      maskTypeSelect.value = this.settings.maskType;
+    }
+    this.applyToRenderer("maskType", this.settings.maskType);
 
     // Apply monochrome mode
     const monochromeSelect =

--- a/src/js/display/display-settings-window.js
+++ b/src/js/display/display-settings-window.js
@@ -16,13 +16,89 @@ export class DisplaySettingsWindow extends BaseWindow {
       id: "display-settings",
       title: "Display Settings",
       minWidth: 260,
-      minHeight: 300,
+      minHeight: 240,
       defaultWidth: 300,
-      defaultHeight: 500,
+      // Sized for the collapsed window. Opening Advanced grows it to fit.
+      defaultHeight: 330,
     });
 
     this.renderer = renderer;
     this.wasmModule = wasmModule;
+
+    // Monitor presets. Each names a real thing a //e was plugged into, and
+    // sets the whole picture in one go — the sliders underneath are the
+    // advanced view of whatever the preset just chose.
+    //
+    // Presets deliberately do not touch brightness, contrast, saturation or the
+    // bezel. Those are the user's own calibration and framing, not properties
+    // of the monitor being imitated, and silently resetting them when someone
+    // switches preset would be obnoxious.
+    this.monitorPresets = [
+      {
+        id: "flat",
+        label: "Pixel Exact",
+        description: "No CRT simulation — sharp square pixels.",
+        values: {
+          curvature: 0, overscan: 0, scanlines: 0, beamBloom: 60,
+          shadowMask: 0, maskType: 0, phosphorGlow: 0, vignette: 0,
+          rgbOffset: 0, flicker: 0, staticNoise: 0, jitter: 0,
+          horizontalSync: 0, glowingLine: 0, ambientLight: 0, burnIn: 0,
+          colorBleed: 0, ntscFringing: 0, monochromeMode: 0, sharpPixels: true,
+        },
+      },
+      {
+        id: "composite",
+        label: "Composite Color",
+        description: "Colour TV or composite monitor — soft, with artefact fringing.",
+        values: {
+          curvature: 20, overscan: 0, scanlines: 30, beamBloom: 60,
+          // A consumer colour set used a dot triad, not a grille.
+          shadowMask: 30, maskType: 1, phosphorGlow: 15, vignette: 20,
+          rgbOffset: 6, flicker: 0, staticNoise: 0, jitter: 0,
+          horizontalSync: 0, glowingLine: 0, ambientLight: 0, burnIn: 10,
+          colorBleed: 80, ntscFringing: 60, monochromeMode: 0, sharpPixels: false,
+        },
+      },
+      {
+        id: "rgb",
+        label: "RGB Monitor",
+        description: "Separate colour signals — sharp, no composite artefacts.",
+        values: {
+          curvature: 10, overscan: 0, scanlines: 22, beamBloom: 45,
+          shadowMask: 22, maskType: 0, phosphorGlow: 8, vignette: 12,
+          rgbOffset: 0, flicker: 0, staticNoise: 0, jitter: 0,
+          horizontalSync: 0, glowingLine: 0, ambientLight: 0, burnIn: 5,
+          // No encoding to decode, so no fringing and almost no chroma bleed.
+          colorBleed: 15, ntscFringing: 0, monochromeMode: 0, sharpPixels: true,
+        },
+      },
+      {
+        id: "green",
+        label: "Monochrome Green",
+        description: "P1 phosphor — long persistence, no mask.",
+        values: {
+          curvature: 20, overscan: 0, scanlines: 32, beamBloom: 70,
+          // A monochrome tube has one continuous phosphor coating and no
+          // aperture at all — a mask exists only to keep three beams apart.
+          shadowMask: 0, maskType: 0, phosphorGlow: 28, vignette: 25,
+          rgbOffset: 0, flicker: 0, staticNoise: 0, jitter: 0,
+          horizontalSync: 0, glowingLine: 0, ambientLight: 0, burnIn: 40,
+          colorBleed: 25, ntscFringing: 0, monochromeMode: 1, sharpPixels: false,
+        },
+      },
+      {
+        id: "amber",
+        label: "Monochrome Amber",
+        description: "P3 phosphor — the warmer of the two mono tubes.",
+        values: {
+          curvature: 20, overscan: 0, scanlines: 32, beamBloom: 70,
+          shadowMask: 0, maskType: 0, phosphorGlow: 25, vignette: 25,
+          rgbOffset: 0, flicker: 0, staticNoise: 0, jitter: 0,
+          horizontalSync: 0, glowingLine: 0, ambientLight: 0, burnIn: 35,
+          colorBleed: 25, ntscFringing: 0, monochromeMode: 2, sharpPixels: false,
+        },
+      },
+    ];
 
     // Monochrome mode options
     this.maskTypes = [
@@ -40,6 +116,9 @@ export class DisplaySettingsWindow extends BaseWindow {
     // Default values (percentages 0-100 for UI, converted to shader values)
     // All effects off by default except basic image adjustments
     this.defaults = {
+      // "flat" reproduces what this window has always shipped with — every
+      // effect off — so existing users see no change until they pick a monitor.
+      preset: "flat",
       curvature: 0,
       scanlines: 0,
       // Beam bloom is a property of the spot, not an effect of its own: it only
@@ -79,10 +158,22 @@ export class DisplaySettingsWindow extends BaseWindow {
     // Current values
     this.settings = { ...this.defaults };
 
-    // Slider info for rendering
+    // Slider info for rendering. `advanced` sections live behind the
+    // disclosure; Image stays visible because it is calibration, not
+    // simulation, and is the thing people reach for most often.
     this.sliderConfigs = [
       {
+        section: "Image",
+        advanced: false,
+        sliders: [
+          { id: "brightness", label: "Brightness", param: "brightness" },
+          { id: "contrast", label: "Contrast", param: "contrast" },
+          { id: "saturation", label: "Saturation", param: "saturation" },
+        ],
+      },
+      {
         section: "CRT Effects",
+        advanced: true,
         sliders: [
           { id: "curvature", label: "Screen Curvature", param: "curvature" },
           { id: "overscan", label: "Screen Border", param: "overscan" },
@@ -101,6 +192,7 @@ export class DisplaySettingsWindow extends BaseWindow {
       },
       {
         section: "Analog Effects",
+        advanced: true,
         sliders: [
           { id: "staticNoise", label: "Static Noise", param: "staticNoise" },
           { id: "jitter", label: "Jitter", param: "jitter" },
@@ -116,18 +208,11 @@ export class DisplaySettingsWindow extends BaseWindow {
       },
       {
         section: "Bezel",
+        advanced: true,
         sliders: [
           { id: "screenInset", label: "Bezel Width", param: "screenInset" },
           { id: "bezelSpillReach", label: "Spill Reach", param: "bezelSpillReach" },
           { id: "bezelSpillIntensity", label: "Spill Intensity", param: "bezelSpillIntensity" },
-        ],
-      },
-      {
-        section: "Image",
-        sliders: [
-          { id: "brightness", label: "Brightness", param: "brightness" },
-          { id: "contrast", label: "Contrast", param: "contrast" },
-          { id: "saturation", label: "Saturation", param: "saturation" },
         ],
       },
     ];
@@ -136,7 +221,67 @@ export class DisplaySettingsWindow extends BaseWindow {
   renderContent() {
     let html = '<div class="display-settings-content">';
 
+    // Monitor preset — the primary control. Everything below it is the
+    // detail of whatever this chooses.
+    html += `
+      <div class="settings-section">
+        <div class="settings-section-title">Monitor</div>
+        <select id="ds-preset" class="settings-select">
+          ${this.monitorPresets
+            .map(
+              (p) =>
+                `<option value="${p.id}" ${this.settings.preset === p.id ? "selected" : ""}>${p.label}</option>`,
+            )
+            .join("")}
+          <option value="custom" ${this.settings.preset === "custom" ? "selected" : ""}>Custom</option>
+        </select>
+        <div class="preset-description" id="ds-preset-description">${this._presetDescription()}</div>
+      </div>`;
+
+    html += this._renderSliderSections(false);
+
+    // Everything else is folded away. These are the knobs behind the preset,
+    // not the everyday controls.
+    html += `
+      <div class="settings-section advanced-section">
+        <div class="settings-section-title collapsible" id="ds-advanced-toggle">▶ Advanced</div>
+        <div class="advanced-content hidden" id="ds-advanced-content">`;
+
+    html += this._renderSliderSections(true);
+    html += this._renderRenderingSection();
+    html += this._renderNTSCSection();
+
+    html += `
+        </div>
+      </div>`;
+
+    // Reset button
+    html += `
+      <div class="settings-actions">
+        <button id="ds-reset" class="settings-btn">Reset to Defaults</button>
+      </div>`;
+
+    html += "</div>";
+    return html;
+  }
+
+  /**
+   * Description line for the currently selected preset.
+   */
+  _presetDescription() {
+    const preset = this.monitorPresets.find((p) => p.id === this.settings.preset);
+    return preset ? preset.description : "Hand-tuned settings.";
+  }
+
+  /**
+   * Render the slider sections matching the requested `advanced` flag.
+   */
+  _renderSliderSections(advanced) {
+    let html = "";
+
     for (const section of this.sliderConfigs) {
+      if (Boolean(section.advanced) !== advanced) continue;
+
       html += `<div class="settings-section">
         <div class="settings-section-title">${section.section}</div>`;
 
@@ -161,8 +306,14 @@ export class DisplaySettingsWindow extends BaseWindow {
       html += "</div>";
     }
 
-    // Rendering section with monochrome mode and sharp pixels
-    html += `
+    return html;
+  }
+
+  /**
+   * Rendering section: mask geometry, phosphor colour, filtering.
+   */
+  _renderRenderingSection() {
+    return `
       <div class="settings-section">
         <div class="settings-section-title">Rendering</div>
         <div class="setting-row">
@@ -195,9 +346,13 @@ export class DisplaySettingsWindow extends BaseWindow {
           </label>
         </div>
       </div>`;
+  }
 
-    // NTSC Effects sliders (shader-based)
-    html += `
+  /**
+   * NTSC section: the composite-specific shader effects.
+   */
+  _renderNTSCSection() {
+    return `
       <div class="settings-section">
         <div class="settings-section-title">NTSC Effects</div>
         <div class="setting-row">
@@ -211,15 +366,6 @@ export class DisplaySettingsWindow extends BaseWindow {
           <span class="setting-value" id="ds-val-ntscFringing">${this.settings.ntscFringing}%</span>
         </div>
       </div>`;
-
-    // Reset button
-    html += `
-      <div class="settings-actions">
-        <button id="ds-reset" class="settings-btn">Reset to Defaults</button>
-      </div>`;
-
-    html += "</div>";
-    return html;
   }
 
   setupContentEventListeners() {
@@ -237,6 +383,7 @@ export class DisplaySettingsWindow extends BaseWindow {
             this.settings[slider.id] = value;
             if (valueSpan) valueSpan.textContent = `${value}%`;
             this.applyToRenderer(slider.param, value / 100);
+            this._markCustom(slider.id);
             this.saveSettings();
           });
         }
@@ -253,6 +400,25 @@ export class DisplaySettingsWindow extends BaseWindow {
       });
     }
 
+    // Monitor preset
+    const presetSelect = this.contentElement.querySelector("#ds-preset");
+    if (presetSelect) {
+      presetSelect.addEventListener("change", (e) => {
+        this.applyPreset(e.target.value);
+      });
+    }
+
+    // Advanced disclosure
+    const advToggle = this.contentElement.querySelector("#ds-advanced-toggle");
+    const advContent = this.contentElement.querySelector("#ds-advanced-content");
+    if (advToggle && advContent) {
+      advToggle.addEventListener("click", () => {
+        const hidden = advContent.classList.toggle("hidden");
+        advToggle.textContent = hidden ? "\u25B6 Advanced" : "\u25BC Advanced";
+        this._fitHeightToContent();
+      });
+    }
+
     // Mask type dropdown
     const maskSelect = this.contentElement.querySelector("#ds-maskType");
     if (maskSelect) {
@@ -260,6 +426,7 @@ export class DisplaySettingsWindow extends BaseWindow {
         const value = parseInt(e.target.value, 10);
         this.settings.maskType = value;
         this.applyToRenderer("maskType", value);
+        this._markCustom("maskType");
         this.saveSettings();
       });
     }
@@ -277,6 +444,7 @@ export class DisplaySettingsWindow extends BaseWindow {
         }
         // Tell shader which phosphor color to use
         this.applyToRenderer("monochromeMode", value);
+        this._markCustom("monochromeMode");
         this.saveSettings();
       });
     }
@@ -289,6 +457,7 @@ export class DisplaySettingsWindow extends BaseWindow {
         if (this.renderer) {
           this.renderer.setNearestFilter(this.settings.sharpPixels);
         }
+        this._markCustom("sharpPixels");
         this.saveSettings();
       });
     }
@@ -306,6 +475,7 @@ export class DisplaySettingsWindow extends BaseWindow {
         if (colorBleedValueSpan)
           colorBleedValueSpan.textContent = `${value}%`;
         this.applyToRenderer("colorBleed", value / 100);
+        this._markCustom("colorBleed");
         this.saveSettings();
       });
     }
@@ -321,6 +491,7 @@ export class DisplaySettingsWindow extends BaseWindow {
         this.settings.ntscFringing = value;
         if (ntscValueSpan) ntscValueSpan.textContent = `${value}%`;
         this.applyToRenderer("ntscFringing", value / 100);
+        this._markCustom("ntscFringing");
         this.saveSettings();
       });
     }
@@ -343,6 +514,99 @@ export class DisplaySettingsWindow extends BaseWindow {
     if (this.renderer) {
       this.renderer.setParam(param, value);
     }
+  }
+
+  /**
+   * Adopt a monitor preset, or "custom" to keep the current values.
+   *
+   * Selecting "custom" explicitly is a no-op on purpose: it is the label for
+   * settings the user has already hand-tuned, so choosing it must not throw
+   * that work away.
+   */
+  applyPreset(id) {
+    this.settings.preset = id;
+
+    const preset = this.monitorPresets.find((p) => p.id === id);
+    if (preset) {
+      Object.assign(this.settings, preset.values);
+    }
+
+    this.applyAllSettings();
+    this.saveSettings();
+  }
+
+  /**
+   * Note that a setting was changed by hand.
+   *
+   * Switching the label to "Custom" rather than leaving a preset selected
+   * matters: a preset name that no longer describes what is on screen is worse
+   * than no name at all. The values are left exactly as the user set them —
+   * only the label changes.
+   */
+  _markCustom(changedKey) {
+    const preset = this.monitorPresets.find((p) => p.id === this.settings.preset);
+
+    // A change that does not contradict the preset — brightness, bezel — leaves
+    // the preset intact, because the preset never claimed to set it.
+    if (preset && !(changedKey in preset.values)) return;
+    if (this.settings.preset === "custom") return;
+
+    this.settings.preset = "custom";
+    this._syncPresetUI();
+  }
+
+  /**
+   * Reclaim dead space when the window opens collapsed.
+   */
+  show() {
+    super.show();
+    requestAnimationFrame(() => {
+      const advContent = this.contentElement?.querySelector("#ds-advanced-content");
+      if (advContent && advContent.classList.contains("hidden")) {
+        this._fitHeightToContent({ shrinkOnly: true });
+      }
+    });
+  }
+
+  /**
+   * Grow or shrink the window to fit its content.
+   *
+   * Called when the disclosure toggles, so collapsing does not leave a tall
+   * empty box and expanding does not bury the sliders behind a scrollbar.
+   * On open it is shrink-only and only while collapsed: with the disclosure
+   * shut there is nothing to scroll to, so trailing empty space is pure waste,
+   * but growing the window would override a size the user chose themselves.
+   */
+  _fitHeightToContent({ shrinkOnly = false } = {}) {
+    const inner = this.contentElement?.querySelector(".display-settings-content");
+    if (!this.element || !inner) return;
+
+    const headerHeight = this.headerElement ? this.headerElement.offsetHeight : 0;
+    const style = getComputedStyle(this.contentElement);
+    const padding =
+      parseFloat(style.paddingTop || 0) + parseFloat(style.paddingBottom || 0);
+
+    const desired = Math.ceil(inner.scrollHeight + headerHeight + padding);
+    const available = window.innerHeight - this.currentY - 12;
+    let height = Math.max(this.minHeight, Math.min(desired, available));
+    if (shrinkOnly) height = Math.min(height, this.currentHeight);
+    if (height === this.currentHeight) return;
+
+    this.element.style.height = `${height}px`;
+    this.currentHeight = height;
+
+    if (this.onStateChange) this.onStateChange();
+  }
+
+  /**
+   * Push the current preset id into the select and description line.
+   */
+  _syncPresetUI() {
+    const select = this.contentElement?.querySelector("#ds-preset");
+    if (select) select.value = this.settings.preset;
+
+    const description = this.contentElement?.querySelector("#ds-preset-description");
+    if (description) description.textContent = this._presetDescription();
   }
 
   applyBezelColor(hex) {
@@ -431,6 +695,8 @@ export class DisplaySettingsWindow extends BaseWindow {
 
     // Apply NTSC fringing settings (shader-based)
     this.applyNTSCSettings();
+
+    this._syncPresetUI();
   }
 
   resetToDefaults() {

--- a/src/js/display/no-signal-frame.js
+++ b/src/js/display/no-signal-frame.js
@@ -1,0 +1,175 @@
+/*
+ * no-signal-frame.js - Builds the "no signal" screen shown while the emulator
+ * is powered off.
+ *
+ * Written by
+ *  Mike Daley <michael_daley@icloud.com>
+ *
+ * This produces an ordinary RGBA framebuffer in the emulator's own 560x384
+ * layout, which the renderer uploads as the source texture. It therefore goes
+ * through the whole CRT chain — RGB shift, colour bleed, NTSC fringing,
+ * scanlines, shadow mask, glow — exactly as emulator video does, so the message
+ * reads as a composite signal rather than as text pasted over the screen.
+ *
+ * Everything here is static. It replaced a full-screen animated TV-static
+ * effect that regenerated at 50Hz with a 12Hz whole-screen brightness
+ * modulation on top: a full-field flash well inside the 3-30Hz band that
+ * triggers photosensitive epilepsy, and a WCAG 2.3.1 failure. Nothing drawn on
+ * this screen may animate.
+ */
+
+// 5x7 bitmap font, one entry per glyph, seven rows of five bits (MSB left).
+// Effectively uppercase-only — this is machine-generated video from an era that
+// was too — so callers pass strings already in the case they want drawn.
+const FONT = {
+  A: [0x0e, 0x11, 0x11, 0x1f, 0x11, 0x11, 0x11],
+  B: [0x1e, 0x11, 0x11, 0x1e, 0x11, 0x11, 0x1e],
+  C: [0x0e, 0x11, 0x10, 0x10, 0x10, 0x11, 0x0e],
+  D: [0x1e, 0x11, 0x11, 0x11, 0x11, 0x11, 0x1e],
+  E: [0x1f, 0x10, 0x10, 0x1e, 0x10, 0x10, 0x1f],
+  F: [0x1f, 0x10, 0x10, 0x1e, 0x10, 0x10, 0x10],
+  G: [0x0e, 0x11, 0x10, 0x17, 0x11, 0x11, 0x0f],
+  H: [0x11, 0x11, 0x11, 0x1f, 0x11, 0x11, 0x11],
+  I: [0x0e, 0x04, 0x04, 0x04, 0x04, 0x04, 0x0e],
+  J: [0x01, 0x01, 0x01, 0x01, 0x01, 0x11, 0x0e],
+  K: [0x11, 0x12, 0x14, 0x18, 0x14, 0x12, 0x11],
+  L: [0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x1f],
+  M: [0x11, 0x1b, 0x15, 0x15, 0x11, 0x11, 0x11],
+  N: [0x11, 0x19, 0x15, 0x13, 0x11, 0x11, 0x11],
+  O: [0x0e, 0x11, 0x11, 0x11, 0x11, 0x11, 0x0e],
+  P: [0x1e, 0x11, 0x11, 0x1e, 0x10, 0x10, 0x10],
+  Q: [0x0e, 0x11, 0x11, 0x11, 0x15, 0x12, 0x0d],
+  R: [0x1e, 0x11, 0x11, 0x1e, 0x14, 0x12, 0x11],
+  S: [0x0f, 0x10, 0x10, 0x0e, 0x01, 0x01, 0x1e],
+  T: [0x1f, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04],
+  U: [0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x0e],
+  V: [0x11, 0x11, 0x11, 0x11, 0x11, 0x0a, 0x04],
+  W: [0x11, 0x11, 0x11, 0x15, 0x15, 0x1b, 0x11],
+  X: [0x11, 0x11, 0x0a, 0x04, 0x0a, 0x11, 0x11],
+  Y: [0x11, 0x11, 0x0a, 0x04, 0x04, 0x04, 0x04],
+  Z: [0x1f, 0x01, 0x02, 0x04, 0x08, 0x10, 0x1f],
+  0: [0x0e, 0x11, 0x13, 0x15, 0x19, 0x11, 0x0e],
+  1: [0x04, 0x0c, 0x04, 0x04, 0x04, 0x04, 0x0e],
+  2: [0x0e, 0x11, 0x01, 0x02, 0x04, 0x08, 0x1f],
+  3: [0x1f, 0x02, 0x04, 0x02, 0x01, 0x11, 0x0e],
+  4: [0x02, 0x06, 0x0a, 0x12, 0x1f, 0x02, 0x02],
+  5: [0x1f, 0x10, 0x1e, 0x01, 0x01, 0x11, 0x0e],
+  6: [0x06, 0x08, 0x10, 0x1e, 0x11, 0x11, 0x0e],
+  7: [0x1f, 0x01, 0x02, 0x04, 0x08, 0x08, 0x08],
+  8: [0x0e, 0x11, 0x11, 0x0e, 0x11, 0x11, 0x0e],
+  9: [0x0e, 0x11, 0x11, 0x0f, 0x01, 0x02, 0x0c],
+  ".": [0x00, 0x00, 0x00, 0x00, 0x00, 0x0c, 0x0c],
+  ",": [0x00, 0x00, 0x00, 0x00, 0x0c, 0x04, 0x08],
+  "-": [0x00, 0x00, 0x00, 0x1f, 0x00, 0x00, 0x00],
+  "/": [0x01, 0x01, 0x02, 0x04, 0x08, 0x10, 0x10],
+  ":": [0x00, 0x0c, 0x0c, 0x00, 0x0c, 0x0c, 0x00],
+  "!": [0x04, 0x04, 0x04, 0x04, 0x04, 0x00, 0x04],
+  " ": [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+  // Lowercase is limited to what the model name needs.
+  e: [0x00, 0x00, 0x0e, 0x11, 0x1f, 0x10, 0x0e],
+};
+
+const GLYPH_W = 5;
+const GLYPH_H = 7;
+
+// One logical Apple pixel is two framebuffer pixels across and two down, so a
+// character cell here matches the 7x8 cell of the real 40-column text screen.
+const PIXEL = 2;
+const CELL_W = 7 * PIXEL;
+const CELL_H = 8 * PIXEL;
+
+// Composite white is never paper white. This is the level the emulator's own
+// text output sits at, so the message matches what appears a moment later.
+const FG = [0xe8, 0xe8, 0xe8];
+const DIM = [0x8c, 0x8c, 0x8c];
+
+/**
+ * Build the powered-off screen.
+ *
+ * @param {number} width  framebuffer width in pixels (560)
+ * @param {number} height framebuffer height in pixels (384)
+ * @returns {Uint8Array} RGBA pixel data, width * height * 4 bytes
+ */
+export function buildNoSignalFrame(width = 560, height = 384) {
+  const buf = new Uint8Array(width * height * 4);
+
+  // Opaque black — the shader's vignette and bezel do the rest.
+  for (let i = 3; i < buf.length; i += 4) buf[i] = 0xff;
+
+  const plot = (x, y, rgb) => {
+    if (x < 0 || y < 0 || x >= width || y >= height) return;
+    const o = (y * width + x) * 4;
+    buf[o] = rgb[0];
+    buf[o + 1] = rgb[1];
+    buf[o + 2] = rgb[2];
+  };
+
+  const fillRect = (x, y, w, h, rgb) => {
+    for (let dy = 0; dy < h; dy++) {
+      for (let dx = 0; dx < w; dx++) plot(x + dx, y + dy, rgb);
+    }
+  };
+
+  // Draw text centred on the given framebuffer row, one character per cell.
+  const drawTextCentred = (text, top, rgb, scale = 1) => {
+    const cellW = CELL_W * scale;
+    const runW = text.length * cellW;
+    let x = Math.round((width - runW) / 2);
+    for (const ch of text) {
+      const glyph = FONT[ch] || FONT[" "];
+      for (let row = 0; row < GLYPH_H; row++) {
+        const bits = glyph[row];
+        for (let col = 0; col < GLYPH_W; col++) {
+          if (!(bits & (1 << (GLYPH_W - 1 - col)))) continue;
+          fillRect(
+            x + col * PIXEL * scale,
+            top + row * PIXEL * scale,
+            PIXEL * scale,
+            PIXEL * scale,
+            rgb,
+          );
+        }
+      }
+      x += cellW;
+    }
+  };
+
+  // IEC 5009 power symbol: a broken ring with a bar rising through the gap.
+  // Drawn from the distance field rather than with strokes so the edges land on
+  // whole framebuffer pixels and survive the shader's sampling without shimmer.
+  const drawPowerSymbol = (cx, cy, radius, thickness, rgb) => {
+    const inner = radius - thickness / 2;
+    const outer = radius + thickness / 2;
+    const extent = Math.ceil(outer);
+    // Half-angle of the gap at the top, measured from vertical.
+    const gap = 0.42;
+
+    for (let y = -extent; y <= extent; y++) {
+      for (let x = -extent; x <= extent; x++) {
+        const d = Math.sqrt(x * x + y * y);
+        if (d < inner || d > outer) continue;
+        // Screen y grows downward, so the top of the ring is negative y.
+        if (y < 0 && Math.abs(Math.atan2(x, -y)) < gap) continue;
+        plot(cx + x, cy + y, rgb);
+      }
+    }
+
+    // The bar rises through the gap and stops just short of the centre. Odd
+    // width so it straddles the centre column exactly.
+    const half = Math.floor(thickness / 2);
+    const barTop = Math.round(cy - radius - thickness);
+    const barBottom = Math.round(cy - radius * 0.1);
+    fillRect(cx - half, barTop, half * 2 + 1, barBottom - barTop, rgb);
+  };
+
+  // Vertical layout, top down: heading, message, power symbol. Rows are snapped
+  // to whole character cells so the text sits on the same grid the emulator's
+  // own text screen uses.
+  const cellRow = (row) => row * CELL_H;
+
+  drawTextCentred("NO SIGNAL", cellRow(6), FG, 2);
+  drawTextCentred("SWITCH ON THE APPLE //e TO START", cellRow(11), DIM);
+  drawPowerSymbol(Math.round(width / 2), cellRow(16), 18, 5, FG);
+
+  return buf;
+}

--- a/src/js/display/webgl-renderer.js
+++ b/src/js/display/webgl-renderer.js
@@ -6,6 +6,7 @@
  */
 
 import { VERSION } from "../config/version.js";
+import { buildNoSignalFrame } from "./no-signal-frame.js";
 
 export class WebGLRenderer {
   constructor(canvas) {
@@ -66,9 +67,6 @@ export class WebGLRenderer {
 
       // Screen border/overscan
       overscan: 0.0, // Border around display content (0.0 to 1.0)
-
-      // No signal mode (TV static when off)
-      noSignal: 0.0, // 1.0 = full static, 0.0 = normal display
 
       // Color bleed - vertical inter-scanline blending (CRT phosphor overlap)
       colorBleed: 0.8, // 0.0 to 1.0
@@ -244,7 +242,6 @@ export class WebGLRenderer {
       ambientLight: gl.getUniformLocation(this.program, "u_ambientLight"),
       burnIn: gl.getUniformLocation(this.program, "u_burnIn"),
       overscan: gl.getUniformLocation(this.program, "u_overscan"),
-      noSignal: gl.getUniformLocation(this.program, "u_noSignal"),
       colorBleed: gl.getUniformLocation(this.program, "u_colorBleed"),
       ntscFringing: gl.getUniformLocation(this.program, "u_ntscFringing"),
       monochromeMode: gl.getUniformLocation(this.program, "u_monochromeMode"),
@@ -413,6 +410,11 @@ export class WebGLRenderer {
 
   updateTexture(data) {
     const gl = this.gl;
+
+    // While the no-signal screen is up it owns the texture. A frame can still
+    // arrive from the Worker just after power-off; without this it would land
+    // on top of the message and leave the last emulator frame frozen on screen.
+    if (this._noSignal && data !== this._noSignalFrame) return;
 
     // Frames normally arrive as a view onto a SharedArrayBuffer and upload
     // straight from it. Current browsers accept a shared view here, but the
@@ -600,7 +602,6 @@ export class WebGLRenderer {
       gl.uniform1f(this.uniforms.ambientLight, this.crtParams.ambientLight);
       gl.uniform1f(this.uniforms.burnIn, this.crtParams.burnIn);
       gl.uniform1f(this.uniforms.overscan, this.crtParams.overscan);
-      gl.uniform1f(this.uniforms.noSignal, this.crtParams.noSignal);
       gl.uniform1f(this.uniforms.colorBleed, this.crtParams.colorBleed);
       gl.uniform1f(this.uniforms.ntscFringing, this.crtParams.ntscFringing);
       gl.uniform1i(this.uniforms.monochromeMode, this.crtParams.monochromeMode);
@@ -729,9 +730,22 @@ export class WebGLRenderer {
     }
   }
 
-  // Set no-signal mode (TV static when emulator is off)
+  /**
+   * Enter or leave the powered-off "no signal" screen.
+   *
+   * The message is uploaded as the source texture rather than drawn by the
+   * shader, so it picks up the whole CRT chain — RGB shift, colour bleed, NTSC
+   * fringing, scanlines, mask, glow — and reads as a composite signal. Leaving
+   * the mode uploads nothing: the first real frame overwrites it.
+   */
   setNoSignal(enabled) {
-    this.setParam("noSignal", enabled ? 1.0 : 0.0);
+    this._noSignal = enabled;
+    if (!enabled) return;
+
+    if (!this._noSignalFrame) {
+      this._noSignalFrame = buildNoSignalFrame(this.width, this.height);
+    }
+    this.updateTexture(this._noSignalFrame);
   }
 
   resize(width, height) {

--- a/src/js/display/webgl-renderer.js
+++ b/src/js/display/webgl-renderer.js
@@ -42,6 +42,8 @@ export class WebGLRenderer {
       // How much a bright line's beam spot widens over a dark one's
       beamBloom: 0.6,
       shadowMask: 0.3,
+      // Mask geometry: 0 = aperture grille (stripes), 1 = shadow mask (triad)
+      maskType: 0,
 
       // Glow/bloom
       glowIntensity: 0.0,
@@ -230,6 +232,8 @@ export class WebGLRenderer {
       scanlineWidth: gl.getUniformLocation(this.program, "u_scanlineWidth"),
       beamBloom: gl.getUniformLocation(this.program, "u_beamBloom"),
       shadowMask: gl.getUniformLocation(this.program, "u_shadowMask"),
+      maskType: gl.getUniformLocation(this.program, "u_maskType"),
+      pixelRatio: gl.getUniformLocation(this.program, "u_pixelRatio"),
       glowIntensity: gl.getUniformLocation(this.program, "u_glowIntensity"),
       glowSpread: gl.getUniformLocation(this.program, "u_glowSpread"),
       brightness: gl.getUniformLocation(this.program, "u_brightness"),
@@ -578,6 +582,10 @@ export class WebGLRenderer {
       this.canvas.width,
       this.canvas.height,
     );
+    // Per-frame, not cached: dragging the window to a display of a different
+    // density changes this with no resize and no parameter change, and the mask
+    // pitch depends on it.
+    gl.uniform1f(this.uniforms.pixelRatio, window.devicePixelRatio || 1);
 
     // Static uniforms (only update when CRT parameters change)
     if (this._uniformsDirty !== false) {
@@ -591,6 +599,7 @@ export class WebGLRenderer {
       gl.uniform1f(this.uniforms.scanlineWidth, this.crtParams.scanlineWidth);
       gl.uniform1f(this.uniforms.beamBloom, this.crtParams.beamBloom);
       gl.uniform1f(this.uniforms.shadowMask, this.crtParams.shadowMask);
+      gl.uniform1i(this.uniforms.maskType, this.crtParams.maskType);
       gl.uniform1f(this.uniforms.glowIntensity, this.crtParams.glowIntensity);
       gl.uniform1f(this.uniforms.glowSpread, this.crtParams.glowSpread);
       gl.uniform1f(this.uniforms.brightness, this.crtParams.brightness);

--- a/src/js/display/webgl-renderer.js
+++ b/src/js/display/webgl-renderer.js
@@ -518,11 +518,27 @@ export class WebGLRenderer {
 
     // Apply any pending canvas resize right before painting so the
     // buffer clear and the redraw happen in the same frame (no flicker).
+    // Re-derive the buffer size when the display's pixel density changes.
+    // Dragging the window from a Retina display to a 1x monitor changes
+    // devicePixelRatio without changing any CSS size, so the ResizeObserver
+    // that normally drives resize() never fires and the drawing buffer keeps
+    // the density it was allocated with — leaving the picture over- or
+    // under-sampled until some unrelated resize happens to correct it. There is
+    // no event for this (the matchMedia idiom does not fire reliably), so it is
+    // a comparison here: one float check per frame against a value the shader
+    // already needs.
+    const dpr = window.devicePixelRatio || 1;
+    if (dpr !== this._bufferDpr && this._cssWidth !== undefined) {
+      this._pendingWidth = Math.floor(this._cssWidth * dpr);
+      this._pendingHeight = Math.floor(this._cssHeight * dpr);
+    }
+
     if (this._pendingWidth !== undefined) {
       const pw = this._pendingWidth;
       const ph = this._pendingHeight;
       this._pendingWidth = undefined;
       this._pendingHeight = undefined;
+      this._bufferDpr = dpr;
       if (this.canvas.width !== pw || this.canvas.height !== ph) {
         this.canvas.width = pw;
         this.canvas.height = ph;
@@ -768,6 +784,8 @@ export class WebGLRenderer {
     // mousemove, but draw() only runs once per rAF.  Deferring keeps the
     // buffer clear and the repaint in the same frame, eliminating flicker.
     const dpr = window.devicePixelRatio || 1;
+    this._cssWidth = width;
+    this._cssHeight = height;
     this._pendingWidth = Math.floor(width * dpr);
     this._pendingHeight = Math.floor(height * dpr);
   }

--- a/src/js/display/webgl-renderer.js
+++ b/src/js/display/webgl-renderer.js
@@ -39,6 +39,8 @@ export class WebGLRenderer {
       // Scanlines and rasterization
       scanlineIntensity: 0.03,
       scanlineWidth: 0.25,
+      // How much a bright line's beam spot widens over a dark one's
+      beamBloom: 0.6,
       shadowMask: 0.3,
 
       // Glow/bloom
@@ -226,6 +228,7 @@ export class WebGLRenderer {
         "u_scanlineIntensity",
       ),
       scanlineWidth: gl.getUniformLocation(this.program, "u_scanlineWidth"),
+      beamBloom: gl.getUniformLocation(this.program, "u_beamBloom"),
       shadowMask: gl.getUniformLocation(this.program, "u_shadowMask"),
       glowIntensity: gl.getUniformLocation(this.program, "u_glowIntensity"),
       glowSpread: gl.getUniformLocation(this.program, "u_glowSpread"),
@@ -586,6 +589,7 @@ export class WebGLRenderer {
         this.crtParams.scanlineIntensity,
       );
       gl.uniform1f(this.uniforms.scanlineWidth, this.crtParams.scanlineWidth);
+      gl.uniform1f(this.uniforms.beamBloom, this.crtParams.beamBloom);
       gl.uniform1f(this.uniforms.shadowMask, this.crtParams.shadowMask);
       gl.uniform1f(this.uniforms.glowIntensity, this.crtParams.glowIntensity);
       gl.uniform1f(this.uniforms.glowSpread, this.crtParams.glowSpread);

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -296,6 +296,7 @@ class AppleIIeEmulator {
       });
       joystickWindow.onCursorKeysChanged = (enabled) => {
         this.screenWindow.setCursorKeysState(enabled);
+        this.uiController?.setCursorKeysMenuState(enabled);
       };
 
       const mockingboardWindow = new MockingboardWindow(this.wasmModule);

--- a/src/js/ui/ui-controller.js
+++ b/src/js/ui/ui-controller.js
@@ -552,6 +552,25 @@ export class UIController {
       });
     }
 
+    // --- Cursor keys as joystick (mirrors the Monitor header toggle) ---
+    this.cursorKeysBtn = document.getElementById("btn-cursor-keys-joystick");
+    if (this.cursorKeysBtn) {
+      const joystickWindow = this.windowManager.getWindow("joystick");
+      this.setCursorKeysMenuState(
+        joystickWindow
+          ? joystickWindow.cursorKeysEnabled
+          : localStorage.getItem("joystick-cursor-keys") === "true",
+      );
+      this.cursorKeysBtn.addEventListener("click", () => {
+        const win = this.windowManager.getWindow("joystick");
+        if (win) {
+          win.setCursorKeysEnabled(!win.cursorKeysEnabled);
+        }
+        this.closeAllMenus();
+        this.refocusCanvas();
+      });
+    }
+
     const slotsBtn = document.getElementById("btn-slots");
     if (slotsBtn) {
       slotsBtn.addEventListener("click", () => {
@@ -1132,6 +1151,14 @@ export class UIController {
       iconUnmuted?.classList.remove("hidden");
       iconMuted?.classList.add("hidden");
     }
+  }
+
+  /**
+   * Reflect the cursor-keys-as-joystick state in the View menu
+   * @param {boolean} enabled
+   */
+  setCursorKeysMenuState(enabled) {
+    this.cursorKeysBtn?.classList.toggle("active", enabled);
   }
 
   /**


### PR DESCRIPTION
Seven independent changes, one commit each.

## Accessibility

Two effects were photosensitivity hazards, and both are fixed here.

**The powered-off TV static** regenerated a full-screen high-contrast noise field at 50Hz and modulated the whole screen's brightness by ±10% at 12Hz on top of it — a full-field flash inside the 3–30Hz trigger band, and over the 10% relative luminance change WCAG 2.3.1 counts as a general flash.

**The flicker slider** took a fresh random brightness level and held it for 1/15s: up to fifteen discontinuous whole-screen luminance steps a second. Unlike the static, this one is on during *normal use*. Measured in Chrome at the top of the slider, sampling mean canvas luminance every animation frame for 5s:

| | old | new |
|---|---|---|
| peak-to-peak luminance | 10.60% | **4.40%** |
| largest single-frame step | 9.01% | **0.60%** |
| direction reversals/sec | 9.99 | **2.60** |

The old figures fail WCAG 2.3.1 on both counts — over the 10% threshold, at ~5 flashes/sec against a limit of 3. The replacement is two slow incommensurate sines (~0.78Hz and ~1.25Hz) at a third of the amplitude. A real CRT's visible flicker comes from its field rate beating slowly against the mains, so it undulates rather than stepping — closer to the actual artefact than the noise hash was.

The other animated effects were checked and need no change: `glowingLine` sweeps at 0.05Hz; `jitter` and `horizontalSync` displace geometry rather than modulating luminance.

## No-signal screen

Replacing the static, the powered-off screen now says what to do: "NO SIGNAL", a line telling the user to switch the machine on, and the IEC 5009 power symbol.

It's also more accurate — snow is a *tuner* artefact, and the //e drives a composite monitor with no tuner. Pull the signal from one of those and you get black, not snow.

The message isn't drawn by the shader. It's built as an ordinary 560x384 RGBA framebuffer in the emulator's own layout and uploaded as the source texture, so it passes through the entire CRT chain — RGB shift, colour bleed, NTSC fringing, scanlines, mask, glow, curvature — exactly as emulator video does, and picks up the user's monochrome mode and CRT settings for free. Text comes from a small 5x7 font on the same 7x8 character grid the real 40-column text screen uses.

`updateTexture()` ignores emulator frames while the message is up: a frame can still arrive from the Worker just after power-off, which would otherwise land on top of the message and leave the last emulator frame frozen on screen.

## Beam bloom

A CRT's beam is a Gaussian spot whose diameter grows with beam current, so a bright line is physically fatter than a dark one and fills more of the gap to its neighbours. That's why white text on a CRT looks bolder than the same glyphs in a screenshot, and why dark areas keep a crisp line structure that bright areas lose.

The old comb — a `sin()` raised to a constant power — couldn't express that; it darkened every line by the same fraction regardless of content, which reads as stripes laid over the picture rather than as a raster. Scanline sigma now scales with the luminance actually being displayed at the fragment. Measured in Chrome, screen filled with `W` glyphs, scanlines at 90%:

| beamBloom | bright mean luminance | bright pixels | peak |
|---|---|---|---|
| 0.0 | 122.2 | 73,226 | 255 |
| 0.3 | 141.3 | 78,454 | 255 |
| 0.6 (default) | 153.3 | 80,216 | 255 |
| 1.0 | 161.7 | 81,524 | 255 |

Bright content gains 32% in mean luminance and 11% in area — that area figure is the bolder-strokes effect. Peak stays pinned at 255 across the range, confirming no overshoot. Dark content is unaffected.

Bloom ships on at 60%: it's a property of the spot rather than an effect of its own, and only visible through the scanline comb (which ships at 0), so anyone raising Scanlines gets the good version without hunting for a second slider. `loadSettings()` merges over defaults, so existing users pick it up cleanly.

## Shadow mask

A mask is a perforated sheet a few millimetres behind the glass with a pitch fixed in millimetres. Two things follow, and both were wrong.

**It does not change size.** The pitch came from device pixels — `mod(pos.x, 3.0)` on a coordinate scaled by `u_resolution` — so on a Retina display the whole triad spanned three physical pixels (which is why the slider appeared to do so much less than it should), and the pattern resized whenever the window moved between displays of different density. Measured by grouping bright pixels by CSS column mod 3 and comparing mean red, at a forced `deviceScaleFactor` with the canvas refit so the drawing buffer really was dpr x CSS size:

| | dpr 1 | dpr 2 |
|---|---|---|
| old | `[255, 178, 177.8]` — 30.3% | `[216.5, 216.5, 177.8]` — **17.9%** |
| new | `[255, 178, 177.8]` — 30.3% | `[255, 178, 177.8]` — **30.3%** |

The old mask halves in apparent size at dpr 2 and its phase stops aligning with CSS columns. The new one is identical at both, deriving position from `gl_FragCoord / u_pixelRatio`.

**It does not move with the signal.** The call passed the beam-distorted UV, so jitter and horizontal sync dragged the mask around with the picture — contradicting the comment two functions up that says the beam wobbles and the mask does not. `gl_FragCoord` ties it to the physical screen.

Adds the **dot triad** the Apple Monitor //e actually used, selectable in Display Settings. Triads sit on a staggered lattice with a gap between rows, which is what stops a shadow mask reading as the vertical stripes of an aperture grille. The grille stays the default since it is what this shader has always drawn. Verified the dropdown drives the uniform and the choice survives a reload.

`u_pixelRatio` is uploaded per frame rather than with the cached parameter block: dragging the window to a display of a different density changes it with no resize and no parameter change.

## Canvas pixel density

Surfaced by the shadow mask work. Dragging the window from a Retina display to a 1x monitor changes `devicePixelRatio` without changing any CSS size, so the `ResizeObserver` that drives `resize()` never fires and the drawing buffer keeps the density it was allocated with — the picture stays over- or under-sampled until some unrelated resize corrects it.

Implemented as a comparison in `draw()` rather than a `matchMedia` listener. The `(resolution: Ndppx)` idiom *evaluates* correctly under a forced `deviceScaleFactor` — the query flips to not-matching — but Chrome does not dispatch its `change` event for that path, so the listener never ran and the fix could not be verified. A float compare per frame, against a value the shader already reads for the mask pitch, is cheap and provable.

Verified over CDP with no manual refit — at dpr 1/2/3 and back to 1 the buffer tracks CSS size x dpr exactly (1026x704, 2052x1408, 3078x2112, 1026x704). Ordinary viewport resizes still drive the buffer, and at steady state no resize stays queued: zero buffer changes over 120 frames, so nothing reallocates per frame.

## Display settings: monitor presets

The window had grown to sixteen sliders and two dropdowns with no organising principle beyond its section headers, which asks everyone to understand shadow mask pitch and NTSC fringing before they can make the picture look like a monitor they remember.

A **Monitor** preset now leads and sets the whole picture in one choice — Pixel Exact, Composite Color, RGB Monitor, Monochrome Green, Monochrome Amber. Each is a real thing a //e was plugged into, and the values follow from that: the composite set gets a dot triad, fringing and heavy chroma bleed; the RGB monitor gets neither fringing nor bleed, because there is no encoding to decode; the monochrome tubes get long persistence and *no mask at all*, since a mask exists only to keep three beams apart and a mono tube has one.

Everything else folds behind an **Advanced** disclosure, using the same collapsible idiom as the soft switch window. Image adjustments stay visible — brightness and contrast are the user's own calibration rather than part of the simulation.

Presets deliberately leave brightness, contrast, saturation and the bezel alone for the same reason. Editing a setting a preset *does* own relabels the selection to Custom without changing any values; editing one it does not own leaves the preset name intact.

Defaults are unchanged: `flat` is exactly what this window has always shipped, so nobody's picture changes until they choose a monitor. The window fits its height to the disclosure state, and on open shrinks to content when collapsed — never grows, so a size the user chose is never overridden.

Verified over CDP: all five presets reach the renderer with the right values, Custom triggers only on preset-owned settings, the choice persists across reload, and the disclosure and refit behave.

## Cursor keys as joystick

The toggle only existed in the Monitor window header, which isn't present outside window layout mode — so in Play, Code and Debug layouts the setting was unreachable. The new View menu item drives the same `setCursorKeysEnabled()`, and the window's change callback updates both, so menu tick, header switch and state restores stay in sync in either direction.

## Testing

Verified in Chrome over CDP, not by inspection — all measurements above are from live runs. No-signal was checked across all three transitions (cold start, power-on replacing the message with the boot screen, power-off returning to it with no frozen frame). The Beam Bloom slider was confirmed to render, drive the uniform, and persist. `npm run check` passes (91 tests). Production Vite build is clean.

Release notes and version bump are deliberately not included — worth doing as part of a release, since the two accessibility changes are visible to anyone who had those effects enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



