### PR TITLE
Release 1.1.13

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ Test suites cover CPU (6502/65C02), memory (MMU, slots), video, audio, disk imag
 - `main.js` - AppleIIeEmulator class orchestrating all subsystems
 - `worker/` - Web Worker infrastructure for WASM isolation (see Worker Architecture below)
 - `audio/` - Web Audio API driver and AudioWorklet
-- `display/` - WebGL renderer, CRT shader effects, display settings, screen window
+- `display/` - WebGL renderer, CRT shader effects, display settings, screen window, no-signal screen
 - `disk-manager/` - Disk drive UI, SmartPort hard drives, persistence, surface rendering, drive sounds, URL-parameter media loading
 - `file-explorer/` - DOS 3.3 and ProDOS disk browser with disassembler
 - `debug/` - Debug window implementations (see Debugging section)
@@ -113,6 +113,22 @@ Light, dark, and system-follow themes controlled by `ThemeManager` (`src/js/ui/t
 Control sytles, sizes and layout must be consistent across the entire app.
 
 **Window surfaces are opaque and carry no `backdrop-filter`.** Use the `--glass-bg`, `--glass-bg-solid` and `--glass-bg-header` tokens for any window, panel, menu or popout background; they are fully opaque in both themes despite the legacy names. Do not reintroduce translucency or blur on these surfaces: they sit over a canvas that repaints 60 times a second, so a backdrop filter forces the compositor to re-blur the full area of every open window on every frame regardless of whether its content changed. Translucency is still correct for two things — dimming scrims behind modals and the window switcher, and accent-tinted inner chips (CPU flags, soft switch badges) layered on an already-opaque window.
+
+### Display / CRT Shader
+
+`public/shaders/crt.glsl` is the whole picture pipeline. Three things in it are load-bearing and must not be undone:
+
+**Animated effects are bounded by the photosensitive-epilepsy limits.** No full-screen luminance modulation may exceed three flashes per second or a 10% relative luminance change (WCAG 2.3.1). `flicker()` is a slow two-sine undulation at 3% amplitude for this reason, and the full-screen TV static that used to play while the machine was off was removed outright — it ran at 50Hz with a 12Hz brightness modulation on top. The constraint is documented in the functions themselves; read those comments before touching them.
+
+**The mask is in physical screen space, the beam is not.** `shadowMask()` derives position from `gl_FragCoord` divided by `u_pixelRatio` — a mask has a fixed pitch in millimetres, so it must neither resize with display density nor move when jitter and horizontal sync displace the picture. Effects that model the *signal* take the distorted UV; effects that model the *glass* do not.
+
+**Scanlines model a beam spot, not a stripe pattern.** `scanlines()` takes the displayed luminance and widens its Gaussian with it, because a CRT beam grows with current. The framebuffer is 560x384 (280x192 doubled), so a scanline pitch is two texel rows — 192 lines.
+
+The powered-off screen is built by `src/js/display/no-signal-frame.js` as an ordinary 560x384 RGBA framebuffer and uploaded as the source texture, so it passes through the whole CRT chain like emulator video. `WebGLRenderer.updateTexture()` ignores emulator frames while it is displayed.
+
+`WebGLRenderer.draw()` re-derives the drawing buffer size when `devicePixelRatio` changes, because a density change alters no CSS size and so never reaches the `ResizeObserver` that drives `resize()`.
+
+Display Settings (`src/js/display/display-settings-window.js`) leads with a **Monitor preset** — Pixel Exact, Composite Color, RGB Monitor, Monochrome Green, Monochrome Amber — with every individual slider behind an Advanced disclosure. Presets set only the picture, never the user's brightness/contrast/saturation or bezel; editing a setting a preset owns relabels the selection Custom without changing values.
 
 ### URL Media Parameters
 
@@ -250,7 +266,7 @@ src/
     ├── config/         # App version
     ├── debug/          # Debug window implementations
     ├── disk-manager/   # Disk drive operations, persistence, surface rendering, sounds
-    ├── display/        # WebGL renderer, CRT shaders, display settings, screen window
+    ├── display/        # WebGL renderer, CRT shaders, display settings, no-signal screen
     ├── file-explorer/  # DOS 3.3 and ProDOS file browser, disassembler
     ├── help/           # Documentation and release notes
     ├── input/          # Keyboard input, text selection, joystick, mouse
@@ -362,7 +378,7 @@ Built-in debug windows accessible via Debug menu:
 | F11              | Step Into                |
 | Shift+F11        | Step Out                 |
 
-The Joystick window has a **Cursor Keys** toggle that also drives the joystick from the arrow keys (full deflection 0/255 per axis). The arrows keep reaching the emulator's keyboard as normal, so ProDOS selectors, catalog menus and BASIC line editing still work while the toggle is on. When enabled, a "CURSOR KEYS" chip appears in the Monitor title bar. The setting persists via localStorage.
+The Joystick window has a **Cursor Keys** toggle that also drives the joystick from the arrow keys (full deflection 0/255 per axis). The arrows keep reaching the emulator's keyboard as normal, so ProDOS selectors, catalog menus and BASIC line editing still work while the toggle is on. When enabled, a "CURSOR KEYS" chip appears in the Monitor title bar. The same toggle is in the View menu (`btn-cursor-keys-joystick`), which is how it is reached in the layouts that have no Monitor title bar; menu item, header switch and state restores are kept in sync through `JoystickWindow.onCursorKeysChanged`. The setting persists via localStorage.
 
 ## Agent / MCP Integration
 

--- a/README.md
+++ b/README.md
@@ -183,14 +183,28 @@ Browse the contents of inserted disks:
 
 ### Display Settings
 
-The display settings window provides configurable CRT shader effects:
+The display settings window opens with a **Monitor** preset that sets the whole picture in one choice:
 
-- Screen curvature, scanlines, shadow mask
-- Phosphor glow, vignette, NTSC fringing
+| Preset | What it imitates |
+|--------|------------------|
+| Pixel Exact | No CRT simulation — sharp square pixels |
+| Composite Color | Colour TV or composite monitor — dot triad mask, artefact fringing, chroma bleed |
+| RGB Monitor | Separate colour signals — sharp, no composite artefacts |
+| Monochrome Green | P1 phosphor — long persistence, no mask |
+| Monochrome Amber | P3 phosphor — the warmer mono tube |
+
+Presets leave brightness, contrast, saturation and the bezel alone; adjusting anything a preset covers relabels it as Custom without changing the value. Every individual control remains under **Advanced**:
+
+- Screen curvature, scanlines, beam bloom, shadow mask (aperture grille or dot triad)
+- Phosphor glow, vignette, NTSC fringing, colour bleed
 - Flicker, static noise, jitter, horizontal sync lines
 - Brightness, contrast, saturation
 - Sharp pixels toggle, overscan/border control
 - Monochrome modes: Green, Amber, White
+
+Scanlines model the beam spot as a Gaussian that widens with brightness, so bright lines are fatter than dark ones — the reason white text on a CRT looks bolder than the same glyphs in a screenshot. The shadow mask has a fixed apparent size regardless of display density.
+
+Animated effects are kept within the accessibility limits for flashing content (no more than three flashes per second, and under a 10% change in screen luminance). Flicker is a slow undulation rather than a rapid random one, and the powered-off screen shows a static no-signal message rather than animated television snow.
 
 ### Expansion Cards
 
@@ -222,7 +236,7 @@ Cards are configured via **View > Expansion Slots**.
 
 ### Joystick & Game Controllers
 
-A floating joystick window provides visual paddle/joystick controls that map to the Apple II game ports ($C064-$C067). Physical game controllers are supported via the Gamepad API — the left stick maps to paddle values and buttons A/B map to Apple II buttons 0/1, with a configurable deadzone. A **Cursor Keys** toggle makes the arrow keys drive the joystick as well as the keyboard — they still reach the emulator, so arrow-key navigation in ProDOS and BASIC keeps working — with an indicator chip in the Monitor title bar when active.
+A floating joystick window provides visual paddle/joystick controls that map to the Apple II game ports ($C064-$C067). Physical game controllers are supported via the Gamepad API — the left stick maps to paddle values and buttons A/B map to Apple II buttons 0/1, with a configurable deadzone. A **Cursor Keys** toggle makes the arrow keys drive the joystick as well as the keyboard — they still reach the emulator, so arrow-key navigation in ProDOS and BASIC keeps working — with an indicator chip in the Monitor title bar when active. The same toggle is in **View > Cursor Keys as Joystick**, which is the way to reach it in the layouts that have no Monitor title bar.
 
 ## Architecture
 

--- a/src/js/config/version.js
+++ b/src/js/config/version.js
@@ -5,4 +5,4 @@
  *  Mike Daley <michael_daley@icloud.com>
  */
 
-export const VERSION = "1.1.12";
+export const VERSION = "1.1.13";

--- a/src/js/display/display-settings-window.js
+++ b/src/js/display/display-settings-window.js
@@ -141,7 +141,10 @@ export class DisplaySettingsWindow extends BaseWindow {
       ambientLight: 0,
       burnIn: 0,
       overscan: 0,
-      sharpPixels: false,
+      // True so the shipped defaults are exactly the "flat" preset. With this
+      // false the window opened saying Pixel Exact while the pixels were being
+      // smoothed by linear filtering, and the label was simply wrong.
+      sharpPixels: true,
       // Color bleed (vertical inter-scanline blending)
       colorBleed: 0,
       // NTSC fringing (shader-based)

--- a/src/js/help/release-notes.js
+++ b/src/js/help/release-notes.js
@@ -12,7 +12,23 @@
 export const RELEASE_NOTES = [
   {
     week: "July 31, 2026",
-    features: [],
+    features: [
+      {
+        title: "Monitor presets",
+        description:
+          "Display Settings now opens with a single choice: which monitor you are pretending to have. Composite Color for a colour television or composite monitor, RGB Monitor for the sharp separate-signal look, Monochrome Green or Monochrome Amber for the two phosphor tubes, or Pixel Exact for no simulation at all. Each sets the whole picture at once, and the values follow from the real hardware — the composite set gets a dot triad mask and colour fringing, the RGB monitor gets neither because there is no encoded signal to decode, and the monochrome tubes get long persistence and no mask at all, since a mask exists only to keep three beams apart and a monochrome tube has a single one. Every individual slider is still there under Advanced. Presets leave your brightness, contrast, saturation and bezel alone, and adjusting anything a preset covers relabels it as Custom without changing what you set.",
+      },
+      {
+        title: "Cursor Keys as joystick is now in the View menu",
+        description:
+          "The toggle that makes the arrow keys drive the joystick only existed in the Monitor window's title bar, which is not on screen in the Play, Code or Debug layouts — so in those layouts the setting could not be reached at all. It is now in the View menu as well, and the two stay in step with each other.",
+      },
+      {
+        title: "A shadow mask you can actually see",
+        description:
+          "The Shadow Mask slider was measuring its pattern in screen pixels rather than in the fixed spacing a real mask has, so on a high-resolution display the whole red-green-blue triad spanned three physical pixels and was very nearly invisible — and it changed size if you moved the window to a different monitor. It now keeps a constant apparent size everywhere. There is also a choice of geometry: the vertical stripes it has always drawn, or the dot triad an Apple Monitor //e actually used.",
+      },
+    ],
     fixes: [
       {
         title: "Arrow keys stopped working when Cursor Keys was on",
@@ -29,6 +45,16 @@ export const RELEASE_NOTES = [
         description:
           "Save a state while a BASIC program was running, load it back, and the BASIC Program Viewer showed the program as idle: no line highlighting, no live variables, no trace. The emulator works out that a program is running by watching for the moment BASIC starts one, and a restored state resumes in the middle of the program, so that moment never came around again. It now works this out from the restored machine itself. Existing saved states load correctly too.",
       },
+      {
+        title: "Two effects could trigger photosensitive seizures",
+        description:
+          "The television static shown when the machine was off rebuilt a full screen of high-contrast noise fifty times a second and varied the brightness of the whole screen twelve times a second on top of that. The Flicker slider did something similar during normal use, holding a random brightness level for a fifteenth of a second at a time. Both sat squarely in the range of flash rates known to trigger seizures, and both exceeded the published limits for how much the brightness of a screen may change and how often. The static has been removed entirely and replaced with a message telling you to switch the machine on. Flicker is now a slow, gentle undulation, which is closer to what a real set does anyway — its brightness drifts as its field rate beats against the mains rather than jumping about. Anyone who had either effect turned up will notice the difference; this is why.",
+      },
+      {
+        title: "The picture did not follow a change of display",
+        description:
+          "Dragging the window from a high-resolution display to an ordinary one, or the other way, left the picture being drawn at the old display's resolution — too soft or needlessly oversampled — until something else happened to resize the window. It now follows the change immediately.",
+      },
     ],
     improvements: [
       {
@@ -40,6 +66,16 @@ export const RELEASE_NOTES = [
         title: "Tidier File menu",
         description:
           "The File menu ended in an empty line under Save States that never had anything to show. The Save States window lists when each slot was saved, including the automatic one, so the menu no longer repeats it.",
+      },
+      {
+        title: "Scanlines that thicken with brightness",
+        description:
+          "A real picture tube's beam grows wider as it gets brighter, so bright lines are fatter than dark ones and fill more of the gap to their neighbours. It is why white text on a CRT looks bolder than the same text in a screenshot. The scanlines here were a fixed pattern that dimmed everything equally regardless of what was on it, which reads as stripes laid over the picture rather than as a picture made of lines. They now respond to brightness, with a Beam Bloom slider to control how strongly.",
+      },
+      {
+        title: "A no-signal screen instead of snow",
+        description:
+          "The television static reworked earlier this week is gone, for the accessibility reasons above. With the machine switched off you now get NO SIGNAL, a line telling you to switch it on, and a power symbol — drawn as though the machine itself were producing it, so it picks up whatever screen curvature, scanlines, colour and phosphor settings you have chosen. It is also more accurate than snow: snow is something a television tuner produces, and a //e is plugged into a monitor that has no tuner. Pull the signal from one of those and you get a black screen.",
       },
     ],
   },


### PR DESCRIPTION
Version bump, release notes, README and CLAUDE.md for the CRT and accessibility work merged in #54.

## Contents

- **Version** → 1.1.13
- **Release notes** — three features (monitor presets, View menu cursor-keys toggle, shadow mask), two fixes (photosensitivity, display density), two improvements (beam bloom, no-signal screen)
- **README** — Display Settings section rewritten around the preset table; joystick section notes the View menu route
- **CLAUDE.md** — new "Display / CRT Shader" section recording the three constraints that are load-bearing in `crt.glsl` (the photosensitivity limits, mask-in-physical-space vs beam-in-signal-space, and the scanline beam model), plus the no-signal texture path and the DPR tracking

## Notes on two judgement calls

**One week block, not two.** 1.1.12 shipped this morning, so a second block dated July 31 would render as "Week of July 31, 2026" twice. The new items are folded into the existing block. The static entry from 1.1.12 stays as the record of what shipped that morning, and the new no-signal entry says plainly that it was removed later the same week and why — rather than quietly deleting a note users may already have read.

**Pixel Exact is now true to its name.** The flat preset sets sharp pixels, but the shipped default had them off — so a fresh install opened saying "Pixel Exact" while linear filtering smoothed the picture. The label was simply wrong. Defaults now match the preset exactly. This changes the out-of-the-box look for **new installs only**; anyone with saved display settings keeps what they had.

## Verified

Fresh profile with cleared storage opens at preset `flat`, sharp pixels on, nearest filtering on, all effects at zero. Release notes render with 38 items across the visible weeks, no `undefined` leaking into the DOM, correct week headers. `npm run check` passes (91 tests), production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
