### PR TITLE
Release 1.1.14

### DIFF
--- a/src/js/config/version.js
+++ b/src/js/config/version.js
@@ -5,4 +5,4 @@
  *  Mike Daley <michael_daley@icloud.com>
  */
 
-export const VERSION = "1.1.13";
+export const VERSION = "1.1.14";

--- a/src/js/help/release-notes.js
+++ b/src/js/help/release-notes.js
@@ -11,6 +11,18 @@
 
 export const RELEASE_NOTES = [
   {
+    week: "August 2, 2026",
+    features: [],
+    fixes: [
+      {
+        title: "The no-signal screen no longer shows a power symbol",
+        description:
+          "The screen shown while the machine is off had a power symbol drawn beneath the message. It was part of the picture rather than a control — the emulator's screen does nothing with a click — so it invited people to press the one thing on screen that could not work, instead of the power button in the toolbar. It has been removed and the message re-centred.",
+      },
+    ],
+    improvements: [],
+  },
+  {
     week: "July 31, 2026",
     features: [
       {


### PR DESCRIPTION
Version bump and release notes for the one change since 1.1.13: the power symbol removed from the no-signal screen (#56).

README and CLAUDE.md needed no changes — neither described the symbol, and nothing structural moved. Noting that explicitly since the release process calls for reviewing both.

The 1.1.13 note that mentions the symbol is left as it stands: it was true of that release. This entry supersedes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
