### PR TITLE
Give the slot defaults a single source of truth

### DIFF
--- a/src/js/ui/slot-configuration-window.js
+++ b/src/js/ui/slot-configuration-window.js
@@ -9,6 +9,23 @@ import { BaseWindow } from "../windows/base-window.js";
 import { showToast } from "./toast.js";
 
 /**
+ * Cards installed when there is no saved configuration.
+ *
+ * One map, used both to install the cards and to report what is in a slot when
+ * the core cannot say. It was previously written out twice, and the two copies
+ * disagreed: the installer put Thunderclock in 5 and SmartPort in 7, while the
+ * display fallback had them the other way round. Nothing showed it, because the
+ * fallback is only reached when `_getSlotCard` returns nothing, but at that
+ * point the window would have described slots that did not match the machine.
+ */
+const DEFAULT_SLOT_CONFIG = {
+  4: "mockingboard",
+  5: "thunderclock",
+  6: "disk2",
+  7: "smartport",
+};
+
+/**
  * SlotConfigurationWindow - Configure Apple IIe expansion slots
  * Visual drag-and-drop card tray and motherboard slot layout
  */
@@ -490,13 +507,7 @@ export class SlotConfigurationWindow extends BaseWindow {
       }
     }
 
-    const defaults = {
-      4: "mockingboard",
-      5: "smartport",
-      6: "disk2",
-      7: "thunderclock",
-    };
-    return defaults[slot] || "empty";
+    return DEFAULT_SLOT_CONFIG[slot] || "empty";
   }
 
   updateUI() {
@@ -553,7 +564,7 @@ export class SlotConfigurationWindow extends BaseWindow {
 
   async applyInitialSettings() {
     const saved = this.loadSettingsFromStorage();
-    const config = saved || { 4: "mockingboard", 5: "thunderclock", 6: "disk2", 7: "smartport" };
+    const config = saved || DEFAULT_SLOT_CONFIG;
     if (this.wasmModule && this.wasmModule._setSlotCard) {
       for (const [slot, cardId] of Object.entries(config)) {
         const slotNum = parseInt(slot, 10);


### PR DESCRIPTION
The default card assignments were written out twice, and the two copies disagreed:

| | slot 4 | slot 5 | slot 6 | slot 7 |
|---|---|---|---|---|
| `applyInitialSettings()` — installs the cards | mockingboard | **thunderclock** | disk2 | **smartport** |
| `getCurrentSlotCard()` — display fallback | mockingboard | **smartport** | disk2 | **thunderclock** |

The fallback is only reached when `_getSlotCard` returns nothing, so this never showed in normal use. But that is precisely the moment the core cannot report its own configuration — and the window would have confidently described two slots as holding the wrong cards.

Both paths now read one `DEFAULT_SLOT_CONFIG` map, so they cannot drift apart again. The fix is deduplication rather than correcting the copy, because a second copy would eventually disagree again.

## Verified in the browser

Against a cleared `a2e-slot-config`:

- **Core reports:** `{4: mockingboard, 5: thunderclock, 6: disk2, 7: smartport}`
- **Fallback path** (forced by making `_getSlotCard` return nothing): the same

Restoring the old map reproduces the mismatch (`5: smartport, 7: thunderclock`), which confirms this was the live behaviour and not a misreading of the code.

Found while refreshing the wiki, where documenting the defaults meant working out which of the two maps was authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
