### PR TITLE
Only offer to save an ejected disk that actually changed

### DIFF
--- a/src/core/disk-image/woz_disk_image.cpp
+++ b/src/core/disk-image/woz_disk_image.cpp
@@ -318,7 +318,11 @@ void WozDiskImage::createBlank() {
   }
 
   loaded_ = true;
-  modified_ = true;  // Mark as modified so it will be saved
+
+  // Deliberately NOT marked modified. Creating the disk is not a change to it:
+  // a blank disk nobody has written to holds nothing worth saving, and marking
+  // it here made every eject offer to save an empty image.
+  modified_ = false;
 }
 
 bool WozDiskImage::isLoaded() const { return loaded_; }

--- a/src/css/modals.css
+++ b/src/css/modals.css
@@ -407,6 +407,27 @@ div.modal.hidden {
     box-shadow: 0 0 0 3px rgba(88, 166, 255, 0.15);
 }
 
+/* Single-line prompt input (showPrompt) — matches .modal-input-group input */
+.modal-input {
+    width: 100%;
+    box-sizing: border-box;
+    margin-top: var(--space-sm);
+    padding: var(--space-sm) var(--space-md);
+    background: var(--bg-dark);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-md);
+    color: var(--text-primary);
+    font-family: var(--font-mono);
+    font-size: 0.875rem;
+    transition: all 0.2s;
+}
+
+.modal-input:focus {
+    outline: none;
+    border-color: var(--accent-blue);
+    box-shadow: 0 0 0 3px rgba(88, 166, 255, 0.15);
+}
+
 .modal-footer {
     display: flex;
     justify-content: flex-end;

--- a/src/js/disk-manager/disk-operations.js
+++ b/src/js/disk-manager/disk-operations.js
@@ -10,6 +10,51 @@ import {
   clearDiskFromStorage,
   addToRecentDisks,
 } from "./disk-persistence.js";
+import { showPrompt } from "../ui/confirm.js";
+
+/**
+ * Fingerprint the disk image as the emulator would currently serialise it.
+ *
+ * `_isDiskModified` only records that a write happened at some point, which is
+ * not the same question as whether the image differs from the one that went in.
+ * Software rewrites sectors with identical content routinely, and that should
+ * not produce a save prompt. Comparing a fingerprint taken at insert with one
+ * taken at eject answers the question actually being asked.
+ *
+ * Both fingerprints come from `_getDiskData`, so they are produced by the same
+ * serialiser and are directly comparable — the raw file bytes are not, since a
+ * DSK is re-encoded on the way in.
+ *
+ * @param {Object} wasmModule - The WASM module
+ * @param {number} driveNum - Drive number (0 or 1)
+ * @returns {Promise<string|null>} Fingerprint, or null if the image is unreadable
+ */
+export async function fingerprintDisk(wasmModule, driveNum) {
+  const sizePtr = await wasmModule._malloc(4);
+  if (!sizePtr) return null;
+
+  try {
+    const dataPtr = await wasmModule._getDiskData(driveNum, sizePtr);
+    if (!dataPtr) return null;
+
+    const size = await wasmModule.heapDataViewU32(sizePtr);
+    if (size <= 0 || size > 10000000) return null;
+
+    const bytes = await wasmModule.heapRead(dataPtr, size);
+
+    // FNV-1a. Not cryptographic — it only has to catch a disk that changed,
+    // and a collision would at worst skip a save prompt for an image whose
+    // every byte hashed identically.
+    let hash = 0x811c9dc5;
+    for (let i = 0; i < bytes.length; i++) {
+      hash ^= bytes[i];
+      hash = Math.imul(hash, 0x01000193);
+    }
+    return `${size}:${(hash >>> 0).toString(16)}`;
+  } finally {
+    await wasmModule._free(sizePtr);
+  }
+}
 
 /**
  * Helper to insert a disk into WASM with proper memory management
@@ -59,6 +104,7 @@ export async function loadDisk({ wasmModule, drive, driveNum, file, onSuccess, o
       drive.filename = file.name;
       if (drive.ejectBtn) drive.ejectBtn.disabled = false;
       if (drive.browseBtn) drive.browseBtn.disabled = false;
+      drive.baselineFingerprint = await fingerprintDisk(wasmModule, driveNum);
       console.log(`Inserted disk in drive ${driveNum + 1}: ${file.name}`);
 
       // Save to IndexedDB for persistence across sessions
@@ -98,6 +144,7 @@ export async function loadDiskFromData({ wasmModule, drive, driveNum, filename, 
       drive.filename = filename;
       if (drive.ejectBtn) drive.ejectBtn.disabled = false;
       if (drive.browseBtn) drive.browseBtn.disabled = false;
+      drive.baselineFingerprint = await fingerprintDisk(wasmModule, driveNum);
       console.log(`Restored disk in drive ${driveNum + 1}: ${filename}`);
       if (onSuccess) onSuccess(filename);
     } else {
@@ -129,6 +176,7 @@ export async function insertBlankDisk({ wasmModule, drive, driveNum, onSuccess, 
   if (success) {
     drive.filename = filename;
     if (drive.ejectBtn) drive.ejectBtn.disabled = false;
+    drive.baselineFingerprint = await fingerprintDisk(wasmModule, driveNum);
     console.log(`Inserted blank disk in drive ${driveNum + 1}`);
     if (onSuccess) onSuccess(filename);
   } else {
@@ -150,6 +198,7 @@ export function performEject({ wasmModule, drive, driveNum, onEject }) {
   wasmModule._ejectDisk(driveNum);
 
   drive.filename = null;
+  drive.baselineFingerprint = null;
   if (drive.ejectBtn) drive.ejectBtn.disabled = true;
   if (drive.browseBtn) drive.browseBtn.disabled = true;
   if (drive.input) drive.input.value = "";
@@ -170,9 +219,22 @@ export function performEject({ wasmModule, drive, driveNum, onEject }) {
  * @param {Function} [options.onEject] - Callback after ejection
  */
 export async function ejectDisk({ wasmModule, drive, driveNum, onEject }) {
-  // Check if disk is modified
+  // Two gates, cheap one first. `_isDiskModified` says whether anything was
+  // ever written; the fingerprint says whether the image actually differs from
+  // the one that went in. Only the second is the question worth prompting over,
+  // but it costs a serialisation, so it is only asked when a write did happen.
   const hasModifiedCheck = typeof wasmModule._isDiskModified === "function";
-  const isModified = hasModifiedCheck && await wasmModule._isDiskModified(driveNum);
+  let isModified = hasModifiedCheck && await wasmModule._isDiskModified(driveNum);
+
+  if (isModified && drive.baselineFingerprint) {
+    const current = await fingerprintDisk(wasmModule, driveNum);
+    if (current && current === drive.baselineFingerprint) {
+      console.log(
+        `Drive ${driveNum + 1} was written to but its contents are unchanged — ejecting without saving`,
+      );
+      isModified = false;
+    }
+  }
 
   if (isModified) {
     // Generate suggested filename
@@ -253,11 +315,23 @@ export async function saveDiskWithPicker(wasmModule, driveNum, suggestedName) {
       }
       return false;
     }
-  } else {
-    // Fallback for browsers without File System Access API
-    downloadFile(dataCopy, suggestedName);
-    return true;
   }
+
+  // No File System Access API (Safari, Firefox). A download is the only route,
+  // and it neither asks for a name nor offers a way to decline — so ask here
+  // first, rather than silently dropping another file into Downloads.
+  const chosen = await showPrompt(
+    "Save disk image as:",
+    suggestedName,
+    "Save",
+  );
+  if (!chosen) {
+    console.log(`Save cancelled for drive ${driveNum + 1}`);
+    return false;
+  }
+
+  downloadFile(dataCopy, chosen);
+  return true;
 }
 
 /**

--- a/src/js/ui/confirm.js
+++ b/src/js/ui/confirm.js
@@ -11,6 +11,66 @@
  * @param {string} [confirmLabel='OK'] - Label for the confirm button
  * @returns {Promise<boolean>} Resolves true if confirmed, false if cancelled
  */
+/**
+ * Ask for a single line of text using the app's modal styling.
+ *
+ * Used where a native save dialog is wanted but unavailable: Safari and Firefox
+ * have no File System Access API, so the only way to save is a download, which
+ * names the file for you and offers no way to decline. This at least lets the
+ * name be chosen and the save be cancelled.
+ *
+ * @param {string} message - Prompt text
+ * @param {string} [defaultValue=''] - Initial value
+ * @param {string} [confirmLabel='Save'] - Label for the confirm button
+ * @returns {Promise<string|null>} The entered text, or null if cancelled
+ */
+export function showPrompt(message, defaultValue = "", confirmLabel = "Save") {
+  return new Promise((resolve) => {
+    const dialog = document.createElement("dialog");
+    dialog.className = "modal";
+    dialog.innerHTML = `
+      <div class="modal-content">
+        <div class="modal-body">
+          <p>${message}</p>
+          <input type="text" class="modal-input prompt-value" value="${defaultValue.replace(/"/g, "&quot;")}">
+        </div>
+        <div class="modal-footer">
+          <button class="modal-btn modal-btn-secondary prompt-cancel">Cancel</button>
+          <button class="modal-btn modal-btn-primary prompt-ok">${confirmLabel}</button>
+        </div>
+      </div>
+    `;
+
+    document.body.appendChild(dialog);
+    dialog.showModal();
+
+    const input = dialog.querySelector(".prompt-value");
+    input.focus();
+    input.select();
+
+    const cleanup = (result) => {
+      dialog.close();
+      dialog.remove();
+      resolve(result);
+    };
+
+    const accept = () => {
+      const value = input.value.trim();
+      cleanup(value || null);
+    };
+
+    dialog.querySelector(".prompt-ok").addEventListener("click", accept);
+    dialog.querySelector(".prompt-cancel").addEventListener("click", () => cleanup(null));
+    dialog.addEventListener("cancel", () => cleanup(null));
+    input.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        accept();
+      }
+    });
+  });
+}
+
 export function showConfirm(message, confirmLabel = "OK") {
   return new Promise((resolve) => {
     const dialog = document.createElement("dialog");

--- a/tests/unit/test_woz_disk_image.cpp
+++ b/tests/unit/test_woz_disk_image.cpp
@@ -115,11 +115,16 @@ TEST_CASE("WozDiskImage createBlank is not write-protected", "[woz]") {
     REQUIRE_FALSE(img.isWriteProtected());
 }
 
-TEST_CASE("WozDiskImage createBlank is marked as modified", "[woz]") {
+TEST_CASE("WozDiskImage createBlank is not modified until written", "[woz]") {
     WozDiskImage img;
     img.createBlank();
 
-    // createBlank marks the image as modified so it will be saved
+    // Creating a disk is not a change to it. A blank disk nobody has written
+    // to holds nothing worth saving, and marking it modified here made every
+    // eject offer to save an empty image.
+    REQUIRE_FALSE(img.isModified());
+
+    img.writeBit(1);
     REQUIRE(img.isModified());
 }
 


### PR DESCRIPTION
Ejecting a disk kept producing a saved copy. Two separate causes, plus a third thing that made it worse.

## 1. Blank disks were born modified

`WozDiskImage::createBlank()` set the dirty flag on creation, commented *"Mark as modified so it will be saved"*. Creating a disk is not a change to it — a blank disk nobody has written to holds nothing worth saving — so every eject of one offered to save an empty image. It now starts clean, and the first write marks it.

The unit test asserted the old behaviour, so it failed immediately on the change (thank you, test hook). It now asserts the new contract, including that a write still marks the image.

## 2. "Modified" was the wrong question

`_isDiskModified` only ever meant *a write happened at some point*, which is not what's worth prompting over — software rewrites sectors with identical content routinely.

A fingerprint of the serialised image is now taken at insert and compared at eject, so a disk whose contents match the one that went in ejects silently. Both fingerprints come from `_getDiskData`, so they're produced by the same serialiser and are directly comparable — the raw file bytes are not, since a DSK is re-encoded on the way in. The cheap flag is still checked first, so the serialisation only happens when a write actually occurred.

## 3. No save dialog outside Chrome

The code already called `showSaveFilePicker`, but Safari and Firefox don't have the File System Access API, so it fell through to a silent `downloadFile()` — no naming, no way to decline. A new `showPrompt()` dialog now asks for a filename and offers Cancel on those browsers.

There is no true OS save dialog available to a web page in Safari or Firefox; this is the best available there. Chrome and Edge get the real native picker as before.

## What wasn't wrong

Booting DOS 3.3 and idling at the prompt was measured as clean throughout, so ordinary reads were never a cause.

## Verified in the browser

| Case | Before | After |
|---|---|---|
| Blank disk, never written | `_isDiskModified` = 1 | **0** |
| Untouched DOS disk ejected | — | **0 prompts** |
| Blank disk after `INIT` | — | fingerprint `b260bb7d` → `801ceef0`, **1 prompt** |
| Written, contents identical | prompt | **0 prompts** — *"written to but its contents are unchanged"* |

40/40 C++ suites and 91 JS tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
