### PR TITLE
Release 1.1.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Each drive supports:
 - **Insert** — Load a disk image from file
 - **Recent** — Quick access to last 20 used disks (tracked per drive)
 - **Blank** — Create a new formatted blank disk
-- **Eject** — Remove disk (prompts to save if modified)
+- **Eject** — Remove disk (offers to save only if its contents actually changed)
 
 Drag and drop disk files directly onto drives. Drive seek and motor sounds can be toggled on or off.
 

--- a/src/js/config/version.js
+++ b/src/js/config/version.js
@@ -5,4 +5,4 @@
  *  Mike Daley <michael_daley@icloud.com>
  */
 
-export const VERSION = "1.1.14";
+export const VERSION = "1.1.15";

--- a/src/js/help/release-notes.js
+++ b/src/js/help/release-notes.js
@@ -11,6 +11,28 @@
 
 export const RELEASE_NOTES = [
   {
+    week: "August 4, 2026",
+    features: [],
+    fixes: [
+      {
+        title: "Ejecting a disk kept saving a copy of it",
+        description:
+          "Ejecting a disk produced a saved image whether or not anything had been written to it, which quietly filled the downloads folder with copies. There were two reasons. A blank disk was marked as changed the moment it was created, so ejecting one you had never written to always offered to save an empty disk; creating a disk is not a change to it, and it now starts clean. And the emulator was only asking whether a write had happened at some point rather than whether the disk was actually different — software rewrites parts of a disk with identical content as a matter of course. It now compares the disk against the one that went in, and ejects silently when they match. A disk you really have changed still offers to save, as before.",
+      },
+      {
+        title: "Naming a disk image when saving it",
+        description:
+          "On Safari and Firefox, saving an ejected disk dropped a file straight into your downloads with a name chosen for you and no way to decline. Those browsers do not give web pages the system save dialog that Chrome and Edge do, so there is now a dialog asking what to call the image, with a Cancel button. Chrome and Edge continue to use the real system save dialog.",
+      },
+      {
+        title: "Expansion slot defaults disagreed with themselves",
+        description:
+          "The default card layout was written down twice in the code and the two copies had Thunderclock and SmartPort in opposite slots. It only showed if the emulator could not report its own configuration, at which point the slot window would have described two slots wrongly. There is now a single definition.",
+      },
+    ],
+    improvements: [],
+  },
+  {
     week: "August 2, 2026",
     features: [],
     fixes: [


### PR DESCRIPTION
Version bump and release notes for the two fixes merged since 1.1.14.

## Contents

- **Version** → 1.1.15
- **Release notes** — three entries: ejecting a disk kept saving a copy, naming a disk image when saving on Safari/Firefox, and the expansion slot defaults disagreeing with themselves (#58, previously unreleased)
- **README** — the eject description said "prompts to save if modified", which is now the wrong promise; it only offers when the contents actually differ
- **CLAUDE.md** — no change needed; no architecture, file layout or build step moved

## Note for local builds

This release includes a C++ change (`woz_disk_image.cpp`), so anyone building locally needs `npm run build:wasm` rather than just a JS rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
