### PR TITLE
Take deploy targets from the environment

### DIFF
--- a/.env.deploy.example
+++ b/.env.deploy.example
@@ -1,0 +1,8 @@
+# Deploy targets for scripts/deploy.sh — copy to .env.deploy and fill in.
+#
+# .env.deploy is gitignored so the server's user, host and paths stay out of the
+# repository. Any form rsync accepts works, including an SSH host alias defined
+# in ~/.ssh/config. Keep the trailing slash.
+
+DEPLOY_TARGET=myhost:web-a2e/data/
+DEPLOY_STAGING_TARGET=myhost:/srv/web-a2e-staging/data/

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ video-outline.md
 # Local tool state
 .codex/
 .lean-ctx/
+
+# Deploy target configuration (see .env.deploy.example)
+.env.deploy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,11 +14,17 @@ npm run build:wasm    # Build WASM module (required first time and after C++ cha
 npm run dev           # Start dev server at localhost:3000 (hot-reload for JS only)
 npm run build         # Full production build (WASM + Vite bundle)
 npm run clean         # Clean build artifacts
-npm run deploy        # Deploy to VPS via rsync
+npm run deploy        # Deploy to the configured rsync target (see .env.deploy.example)
 npm test              # JavaScript tests (Vitest)
 npm run check         # check:exports + check:core-purity + check:basic-tokens + npm test
 npm run generate:basic-tokens  # Regenerate src/js/utils/basic-tokens.js from C++
 ```
+
+## Deployment
+
+`npm run deploy` (production) and `npm run deploy:staging` run `scripts/deploy.sh`, which rsyncs `dist/` to a target taken from the environment: `DEPLOY_TARGET` and `DEPLOY_STAGING_TARGET`. Copy `.env.deploy.example` to `.env.deploy` and fill it in; that file is gitignored, so the server's user, host and paths stay out of a public repository.
+
+The script is one rsync invocation and nothing else, deliberately: the host locks out additional concurrent SSH sessions, so verification belongs over HTTPS rather than in a second connection.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Open http://localhost:3000 in your browser.
 ```bash
 npm run build         # Full production build (WASM + Vite bundle)
 npm run clean         # Clean build artifacts
-npm run deploy        # Deploy to VPS via rsync
+npm run deploy        # Deploy to the configured rsync target (see .env.deploy.example)
 npm test              # Run the JavaScript test suite (Vitest)
 npm run check         # Consistency checks + JavaScript tests
 ```

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "build:wasm": "mkdir -p build && cd build && emcmake cmake .. && emmake make -j$(nproc 2>/dev/null || sysctl -n hw.ncpu)",
     "preview": "vite preview",
     "clean": "rm -rf build dist public/a2e.js public/a2e.wasm",
-    "deploy": "rsync -avz --delete dist/ vps-mike:web-a2e/data/",
-    "deploy:staging": "rsync -avz --delete dist/ vps-mike:/home/mike/web-a2e-staging/data/"
+    "deploy": "scripts/deploy.sh production",
+    "deploy:staging": "scripts/deploy.sh staging"
   },
   "devDependencies": {
     "vite": "^7.3.1",

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# deploy.sh - Publish dist/ to a configured rsync target
+#
+# The target used to be written into package.json, which put a username and the
+# server's directory layout in a public repository. It now comes from the
+# environment, so the repo says how to deploy without saying where to.
+#
+# Configure either by exporting the variables, or by creating .env.deploy
+# (gitignored) from .env.deploy.example:
+#
+#   DEPLOY_TARGET=user@host:path/          # production
+#   DEPLOY_STAGING_TARGET=user@host:path/  # staging
+#
+# An rsync target may be any form rsync accepts, including an SSH host alias.
+#
+# Deliberately one rsync invocation and nothing else: the server this publishes
+# to locks out additional concurrent SSH sessions, so this script must never
+# grow a "check the result over SSH" step. Verify over HTTPS instead.
+#
+# Written by
+#  Mike Daley <michael_daley@icloud.com>
+
+set -euo pipefail
+
+ENVIRONMENT="${1:-production}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Load .env.deploy without letting it override anything already exported, so an
+# explicit DEPLOY_TARGET=... on the command line still wins.
+ENV_FILE="$REPO_ROOT/.env.deploy"
+if [ -f "$ENV_FILE" ]; then
+    while IFS='=' read -r key value; do
+        case "$key" in
+            ''|\#*) continue ;;
+        esac
+        key="${key%"${key##*[![:space:]]}"}"
+        value="${value#"${value%%[![:space:]]*}"}"
+        value="${value%\"}"; value="${value#\"}"
+        if [ -z "${!key:-}" ]; then
+            export "$key=$value"
+        fi
+    done < "$ENV_FILE"
+fi
+
+case "$ENVIRONMENT" in
+    production)
+        TARGET="${DEPLOY_TARGET:-}"
+        VAR_NAME="DEPLOY_TARGET"
+        ;;
+    staging)
+        TARGET="${DEPLOY_STAGING_TARGET:-}"
+        VAR_NAME="DEPLOY_STAGING_TARGET"
+        ;;
+    *)
+        echo "deploy: unknown environment '$ENVIRONMENT' (expected 'production' or 'staging')" >&2
+        exit 2
+        ;;
+esac
+
+if [ -z "$TARGET" ]; then
+    cat >&2 <<EOF
+deploy: $VAR_NAME is not set.
+
+Set it in the environment, or copy .env.deploy.example to .env.deploy and fill
+it in:
+
+    cp .env.deploy.example .env.deploy
+
+.env.deploy is gitignored, so the target stays out of the repository.
+EOF
+    exit 1
+fi
+
+if [ ! -d "$REPO_ROOT/dist" ]; then
+    echo "deploy: dist/ does not exist — run 'npm run build' first." >&2
+    exit 1
+fi
+
+echo "Deploying dist/ to the $ENVIRONMENT target..."
+exec rsync -avz --delete "$REPO_ROOT/dist/" "$TARGET"


### PR DESCRIPTION
The rsync targets were written into `package.json`, which put the server's username and directory layout in a public repository:

```
rsync -avz --delete dist/ vps-mike:/home/mike/web-a2e-staging/data/
```

None of it is secret — no keys, no host, no IP — but a username is a real head start on an SSH brute-force, and there's no reason for the repo to carry it.

## What changes

- `scripts/deploy.sh` resolves the target from `DEPLOY_TARGET` / `DEPLOY_STAGING_TARGET`
- Values come from the environment or a **gitignored** `.env.deploy`; `.env.deploy.example` documents the format
- `npm run deploy` and `npm run deploy:staging` are unchanged as commands — they just call the script

An explicit variable beats the file, so a one-off target can be passed inline without editing anything.

The script is deliberately one rsync invocation and nothing else, and the comment says why: the host locks out additional concurrent SSH sessions, so it must never grow a "check it worked" step over SSH. Verification belongs over HTTPS.

## Verified

With a stub `rsync` on `PATH`, all four paths produce exactly the commands they replaced:

| Invocation | Result |
|---|---|
| `deploy.sh production` | `rsync -avz --delete …/dist/ vps-mike:web-a2e/data/` |
| `deploy.sh staging` | `rsync -avz --delete …/dist/ vps-mike:/home/mike/web-a2e-staging/data/` |
| `DEPLOY_TARGET=other:/srv/x/ deploy.sh production` | override wins |
| `deploy.sh` (no argument) | defaults to production |

Unknown environment exits 2; a missing target and a missing `dist/` each fail with a usable message. `.env.deploy` confirmed ignored by git.

## Not included

`docker-compose.staging.yml` is still tracked and advertises port 8080 with the staging directory layout. It also looks stale — the live box runs that site as `web-a2e-staging` behind Traefik, not from this file. Left alone since it wasn't part of the ask; worth deleting separately if it's dead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
