### PR TITLE
Remove the stale staging compose file

### DIFF
--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -1,9 +1,0 @@
-services:
-  a2e-staging:
-    image: nginx:alpine
-    container_name: a2e-staging
-    ports:
-      - "8080:80"
-    volumes:
-      - ./web-a2e-staging/data:/usr/share/nginx/html:ro
-    restart: unless-stopped


### PR DESCRIPTION
`docker-compose.staging.yml` described a container named `a2e-staging` publishing port **8080** and serving `./web-a2e-staging/data`.

The staging site doesn't run that way. It runs as `web-a2e-staging` behind Traefik, with no published port of its own — so the file documented infrastructure that doesn't exist, while advertising a port and a directory layout to anyone reading a public repository.

Nothing in the repo referenced it. Follows the deploy-target cleanup in #62.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
