### PR TITLE
Decay phosphor exponentially, per phosphor, against real time

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,8 @@ Control sytles, sizes and layout must be consistent across the entire app.
 
 **The mask is in physical screen space, the beam is not.** `shadowMask()` derives position from `gl_FragCoord` divided by `u_pixelRatio` — a mask has a fixed pitch in millimetres, so it must neither resize with display density nor move when jitter and horizontal sync displace the picture. Effects that model the *signal* take the distorted UV; effects that model the *glass* do not.
 
+**Phosphor persistence is exponential and per-phosphor.** `burnin.glsl` decays each channel by `exp(-dt/tau)` against real elapsed time, not a per-frame subtraction — the pass is throttled to every fourth frame, so a per-frame decay tied persistence to frame rate. In colour mode green holds longest and blue fades quickest, which tints a moving trail green; in monochrome modes one phosphor means one rate for all channels, held longer.
+
 **Scanlines model a beam spot, not a stripe pattern.** `scanlines()` takes the displayed luminance and widens its Gaussian with it, because a CRT beam grows with current. The framebuffer is 560x384 (280x192 doubled), so a scanline pitch is two texel rows — 192 lines.
 
 The powered-off screen is built by `src/js/display/no-signal-frame.js` as an ordinary 560x384 RGBA framebuffer and uploaded as the source texture, so it passes through the whole CRT chain like emulator video. `WebGLRenderer.updateTexture()` ignores emulator frames while it is displayed.

--- a/public/shaders/burnin.glsl
+++ b/public/shaders/burnin.glsl
@@ -2,7 +2,19 @@ precision highp float;
 
 uniform sampler2D u_currentTexture;
 uniform sampler2D u_previousTexture;
-uniform float u_burnInDecay;
+
+// Base time constant in seconds: how long the phosphor takes to fall to 1/e of
+// its brightness. Driven by the Burn In slider.
+uniform float u_burnInTau;
+
+// Seconds since the previous accumulation pass. Decay is a function of elapsed
+// time, not of frames: the pass is throttled to every fourth frame and the
+// frame rate itself varies, so a per-frame decay made persistence depend on how
+// busy the machine was.
+uniform float u_deltaTime;
+
+// 0 = colour, 1 = green, 2 = amber, 3 = white
+uniform int u_monochromeMode;
 
 varying vec2 v_texCoord;
 
@@ -12,10 +24,33 @@ void main() {
     vec3 current = texture2D(u_currentTexture, flippedCoord).rgb;
     vec3 previous = texture2D(u_previousTexture, v_texCoord).rgb;
 
-    // Decay the previous frame
-    vec3 decayed = max(previous - vec3(u_burnInDecay), 0.0);
+    // Phosphor decays exponentially, not linearly. The old code subtracted a
+    // constant each pass, which made every brightness take the same time to
+    // reach black — so a dim trail vanished as slowly as a bright one, and the
+    // decay had a hard edge where it clamped at zero. An exponential falls
+    // quickly at first and then lingers, which is why a real trail has a long
+    // faint tail rather than a visible end.
+    vec3 tau;
 
-    // Take the maximum of current and decayed previous
+    if (u_monochromeMode == 0) {
+        // A colour tube's three phosphors do not decay together. Green persists
+        // longest and blue fades quickest, which is why the trail behind moving
+        // white text on a colour CRT tints green as it dies.
+        tau = u_burnInTau * vec3(1.0, 1.6, 0.7);
+    } else {
+        // A monochrome tube has a single phosphor coating, so there is nothing
+        // to tint: every channel decays at one rate. Long-persistence green and
+        // amber tubes hold noticeably longer than a colour set, which is much
+        // of what makes them feel different to look at.
+        tau = vec3(u_burnInTau * 1.5);
+    }
+
+    // exp(-dt/tau) per channel. A large dt (a backgrounded tab) simply decays
+    // to zero, which is what would really have happened.
+    vec3 decayed = previous * exp(-u_deltaTime / max(tau, vec3(0.0001)));
+
+    // Never darker than what is on screen now: the afterimage is something the
+    // phosphor adds to the picture, never something it takes away.
     vec3 result = max(current, decayed);
 
     gl_FragColor = vec4(result, 1.0);

--- a/src/js/display/webgl-renderer.js
+++ b/src/js/display/webgl-renderer.js
@@ -276,7 +276,9 @@ export class WebGLRenderer {
         this.burnInProgram,
         "u_previousTexture",
       ),
-      burnInDecay: gl.getUniformLocation(this.burnInProgram, "u_burnInDecay"),
+      burnInTau: gl.getUniformLocation(this.burnInProgram, "u_burnInTau"),
+      deltaTime: gl.getUniformLocation(this.burnInProgram, "u_deltaTime"),
+      monochromeMode: gl.getUniformLocation(this.burnInProgram, "u_monochromeMode"),
     };
 
     // Get edge overlay program uniform locations
@@ -501,9 +503,23 @@ export class WebGLRenderer {
     gl.bindTexture(gl.TEXTURE_2D, this.burnInTextures[prevIndex]);
     gl.uniform1i(this.burnInUniforms.previousTexture, 1);
 
-    // Set decay rate - higher burnIn = slower decay
-    const decayRate = 0.02 + (1.0 - this.crtParams.burnIn) * 0.08;
-    gl.uniform1f(this.burnInUniforms.burnInDecay, decayRate);
+    // Time constant in seconds — higher burnIn holds the image longer. The
+    // slider is the phosphor's persistence, not a per-frame subtraction.
+    const tau = 0.06 + this.crtParams.burnIn * 0.9;
+    gl.uniform1f(this.burnInUniforms.burnInTau, tau);
+
+    // Real elapsed time since the last accumulation pass. Clamped because a
+    // backgrounded tab can return with an arbitrarily large gap, and because
+    // the first pass has no previous timestamp to measure from.
+    const now = performance.now() * 0.001;
+    const dt = this._lastBurnInTime === undefined
+      ? 1 / 15
+      : Math.min(now - this._lastBurnInTime, 1.0);
+    this._lastBurnInTime = now;
+    gl.uniform1f(this.burnInUniforms.deltaTime, dt);
+
+    // A monochrome tube has one phosphor, so its channels decay together.
+    gl.uniform1i(this.burnInUniforms.monochromeMode, this.crtParams.monochromeMode);
 
     // Draw
     gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);


### PR DESCRIPTION
Three things were wrong with the burn-in accumulation in `burnin.glsl`.

## 1. Linear decay

`previous - constant` each pass meant every brightness took the same time to reach black — a dim trail faded as slowly as a bright one, and the decay ended abruptly where it clamped at zero. Phosphor decays exponentially: fast at first, then lingering, which is why a real trail has a long faint tail rather than a visible end.

## 2. Uniform across channels

A colour tube's three phosphors don't fade together. Green persists longest, blue goes first — that's why the trail behind moving white text on a CRT tints green as it dies. Monochrome modes now decay all channels at **one** rate instead, because a monochrome tube has a single phosphor coating and nothing to tint, and hold about half again as long.

## 3. Per frame, not per second

The pass is throttled to every fourth frame and the frame rate varies, so persistence depended on how busy the machine was. It's now a function of measured elapsed time, clamped so a backgrounded tab returns to a fully decayed screen rather than a negative timestep.

The Burn In slider now sets a time constant (0.06s–0.96s) rather than a per-frame subtraction.

## Measured in the browser

Charging the buffer with a white frame, then sampling the trail:

**Colour mode** — the green tint is visible in the numbers, and the curve matches the intended exponential within ~3%:

| t (ms) | R | G | B |
|---|---|---|---|
| 47 | 248 | 250 | 245 |
| 632 | 131 | 167 | 98 |
| 2024 | **32** | **70** | **12** |

Predicted at 2.0s from τ = 0.96 / 1.54 / 0.67s: 30 / 67 / 12.

**White monochrome** — R and G identical at every step, B holding a constant 0.90 tint ratio, so the channels decay together as a single phosphor must:

| t (ms) | R | G | B |
|---|---|---|---|
| 48 | 250 | 250 | 225 |
| 617 | 168 | 168 | 151 |
| 2020 | 63 | 63 | 57 |

Both monochrome presets set Burn In high, so this is immediately visible in them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
