### PR TITLE
Release 1.1.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Presets leave brightness, contrast, saturation and the bezel alone; adjusting an
 - Screen curvature, scanlines, beam bloom, shadow mask (aperture grille or dot triad)
 - Phosphor glow, vignette, NTSC fringing, colour bleed
 - Flicker, static noise, jitter, horizontal sync lines
+- Burn In — phosphor persistence, decaying exponentially and per phosphor (green lingers, blue fades first; monochrome tubes decay as one)
 - Brightness, contrast, saturation
 - Sharp pixels toggle, overscan/border control
 - Monochrome modes: Green, Amber, White

--- a/src/js/config/version.js
+++ b/src/js/config/version.js
@@ -5,4 +5,4 @@
  *  Mike Daley <michael_daley@icloud.com>
  */
 
-export const VERSION = "1.1.15";
+export const VERSION = "1.1.16";

--- a/src/js/help/release-notes.js
+++ b/src/js/help/release-notes.js
@@ -11,6 +11,18 @@
 
 export const RELEASE_NOTES = [
   {
+    week: "August 5, 2026",
+    features: [],
+    fixes: [],
+    improvements: [
+      {
+        title: "Phosphor that fades like phosphor",
+        description:
+          "The Burn In effect, which leaves a fading afterimage behind moving graphics, was subtracting a fixed amount of brightness on every pass. That made a dim trail take just as long to disappear as a bright one, and gave the fade an abrupt end where it hit black. Real phosphor fades quickly at first and then lingers, which is why a trail on a picture tube has a long faint tail rather than simply stopping. It now does the same. A colour tube's three phosphors also do not fade together — green holds on longest and blue goes first — so the trail behind moving white text now tints green as it dies, exactly as it does on real hardware. The green and amber monochrome modes instead fade every colour at one rate, because a monochrome tube has a single phosphor coating and nothing to tint, and they hold their image around half again as long. The Burn In slider now sets how long the phosphor holds rather than how much brightness to remove, and the fade no longer runs faster or slower depending on how busy your machine is.",
+      },
+    ],
+  },
+  {
     week: "August 4, 2026",
     features: [],
     fixes: [


### PR DESCRIPTION
Version bump and release notes for the phosphor persistence rework (#64).

The other two merges since 1.1.15 — deploy targets moving to the environment (#62) and deleting the stale staging compose file (#63) — are developer-facing only and change nothing a visitor sees, so they get no release note.

README gains a Burn In line under the advanced effects; it listed every other slider but not that one. CLAUDE.md was updated with the shader contract in #64 itself.

No C++ changed this time, so a JS-only rebuild is sufficient for local builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
