### PR TITLE
Release 1.1.17

### DIFF
--- a/src/js/config/version.js
+++ b/src/js/config/version.js
@@ -5,4 +5,4 @@
  *  Mike Daley <michael_daley@icloud.com>
  */
 
-export const VERSION = "1.1.16";
+export const VERSION = "1.1.17";

--- a/src/js/help/release-notes.js
+++ b/src/js/help/release-notes.js
@@ -11,6 +11,24 @@
 
 export const RELEASE_NOTES = [
   {
+    week: "August 8, 2026",
+    features: [],
+    fixes: [
+      {
+        title: "Colour fringing now behaves like a real tube's",
+        description:
+          "The RGB Offset effect pulls the red, green and blue images slightly apart, imitating the three electron beams not landing in quite the same place. It was doing so evenly across the screen, which left visible colour fringing in the middle of the picture and no more of it in the corners than at the edges — the reverse of a real monitor, where the beams are aligned dead centre and drift further apart the further out they are steered. It is now clean through the middle and worst in the corners, slightly stronger left-to-right than top-to-bottom because a picture tube deflects the beam through a wider angle horizontally. The fringing is also fixed to the screen rather than sliding about with the Jitter and Horizontal Sync effects, since where the beams land is a property of the tube and not of the signal.",
+      },
+    ],
+    improvements: [
+      {
+        title: "The bezel no longer pretends to reflect the screen",
+        description:
+          "The surround around the picture tried to show a reflection of what was on screen. A bezel is matte plastic, and a matte surface scatters light instead of forming an image, so there is no reflection to see on a real monitor however hard you look — the effect was imitating something that does not happen. What a real bezel does is simply catch a little light from a bright screen, which amounts to a faint lightening of the innermost few millimetres and nothing more, so it has been taken out rather than approximated. The Spill Reach and Spill Intensity sliders have gone with it. The bezel keeps its own shading, colour and texture; it just no longer changes with the picture.",
+      },
+    ],
+  },
+  {
     week: "August 5, 2026",
     features: [],
     fixes: [],


### PR DESCRIPTION
Version bump and release notes for the two shader changes since 1.1.16.

## Contents

- **Version** → 1.1.17
- **Fix** — radial convergence error (#66): clean through the middle, worst in the corners, fixed to the screen rather than sliding with jitter
- **Improvement** — the bezel reflection removed (#68)

The bezel rework in #67 isn't mentioned separately: it improved an effect that #68 then removed, so it never reached a release and describing it would only confuse.

The removal takes **two sliders away** — Spill Reach and Spill Intensity — which anyone who had them set will notice, so the note explains why rather than leaving them wondering where the controls went.

README and CLAUDE.md needed no changes: neither documented the spill sliders, and CLAUDE.md's shader section still describes what's actually there.

No C++ changed, so a JS-only rebuild is sufficient for local builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
